### PR TITLE
[Feat] auth API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,14 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.13'
 
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    // IDE support
+    implementation 'org.springframework.boot:spring-boot-configuration-processor'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/kwcapstone/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kwcapstone/server/domain/auth/controller/AuthController.java
@@ -8,6 +8,8 @@ import com.kwcapstone.server.domain.auth.dto.response.AuthSignUpResDTO;
 import com.kwcapstone.server.domain.auth.service.AuthService;
 import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
 import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
+import com.kwcapstone.server.global.util.CookieUtil;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/auth")
 public class AuthController {
     private final AuthService authService;
+    private final CookieUtil cookieUtil;
 
     // 회원가입
     @PostMapping("/signup")
@@ -31,27 +34,48 @@ public class AuthController {
     // 로그인
     @PostMapping("/login")
     public ApiResponse<AuthLoginResDTO> login(
-            @RequestBody @Valid AuthLoginReqDTO request
+            @RequestBody @Valid AuthLoginReqDTO request,
+            HttpServletResponse response
     ) {
-        AuthLoginResDTO result = authService.login(request);
+        AuthService.LoginTokens tokens = authService.login(request);
+        cookieUtil.addRefreshTokenCookie(
+                response,
+                tokens.refreshToken(),
+                tokens.refreshMaxAgeSeconds()
+        );
 
-        return ApiResponse.onSuccess(result, SuccessCode.OK);
+        return ApiResponse.onSuccess(tokens.body(), SuccessCode.OK);
     }
 
-    // Access Token 재발급
+    /**
+     * Access Token 재발급
+     * 1. 클라이언트가 POST /auth/reissue 호출
+     * 2. 브라우저가 refreshToken 쿠키를 자동으로 전송
+     * 3. Controller가 @CookieValue로 refreshToken 추출
+     * 4. Service가 새 accessToken, refreshToken 발급
+     * 5. 새 refreshToken은 쿠키로 재설정 (Refresh Token Rotation)
+     * 6. 새 accessToken은 JSON 응답으로 반환
+     */
     @PostMapping("/reissue")
     public ApiResponse<AuthReissueResDTO> reissue(
-            @RequestHeader("Authorization") String refreshToken
+            @CookieValue(value = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response
     ) {
-        AuthReissueResDTO result = authService.reissue(refreshToken);
+        AuthService.ReissueTokens tokens = authService.reissue(refreshToken);
+        cookieUtil.addRefreshTokenCookie( // Refresh Token Rotation
+                response,
+                tokens.refreshToken(),
+                tokens.refreshMaxAgeSeconds()
+        );
 
-        return ApiResponse.onSuccess(result, SuccessCode.OK);
+        return ApiResponse.onSuccess(new AuthReissueResDTO(tokens.accessToken()), SuccessCode.OK);
     }
 
     // 로그아웃
     @PostMapping("/logout")
-    public ApiResponse<Void> logout() {
+    public ApiResponse<Void> logout(HttpServletResponse response) {
         authService.logout();
+        cookieUtil.clearRefreshTokenCookie(response);
 
         return ApiResponse.onSuccess(null, SuccessCode.OK);
     }

--- a/src/main/java/com/kwcapstone/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kwcapstone/server/domain/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.kwcapstone.server.domain.auth.controller;
 import com.kwcapstone.server.domain.auth.dto.request.AuthLoginReqDTO;
 import com.kwcapstone.server.domain.auth.dto.request.AuthSignUpReqDTO;
 import com.kwcapstone.server.domain.auth.dto.response.AuthLoginResDTO;
+import com.kwcapstone.server.domain.auth.dto.response.AuthReissueResDTO;
 import com.kwcapstone.server.domain.auth.dto.response.AuthSignUpResDTO;
 import com.kwcapstone.server.domain.auth.service.AuthService;
 import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
@@ -35,5 +36,23 @@ public class AuthController {
         AuthLoginResDTO result = authService.login(request);
 
         return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    // Access Token 재발급
+    @PostMapping("/reissue")
+    public ApiResponse<AuthReissueResDTO> reissue(
+            @RequestHeader("Authorization") String refreshToken
+    ) {
+        AuthReissueResDTO result = authService.reissue(refreshToken);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    // 로그아웃
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout() {
+        authService.logout();
+
+        return ApiResponse.onSuccess(null, SuccessCode.OK);
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kwcapstone/server/domain/auth/controller/AuthController.java
@@ -1,9 +1,39 @@
 package com.kwcapstone.server.domain.auth.controller;
 
+import com.kwcapstone.server.domain.auth.dto.request.AuthLoginReqDTO;
+import com.kwcapstone.server.domain.auth.dto.request.AuthSignUpReqDTO;
+import com.kwcapstone.server.domain.auth.dto.response.AuthLoginResDTO;
+import com.kwcapstone.server.domain.auth.dto.response.AuthSignUpResDTO;
+import com.kwcapstone.server.domain.auth.service.AuthService;
+import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
+import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
+    private final AuthService authService;
 
+    // 회원가입
+    @PostMapping("/signup")
+    public ApiResponse<AuthSignUpResDTO> signup(
+            @RequestBody @Valid AuthSignUpReqDTO request
+    ) {
+        AuthSignUpResDTO result = authService.signup(request);
+
+        return ApiResponse.onSuccess(result, SuccessCode.CREATED);
+    }
+
+    // 로그인
+    @PostMapping("/login")
+    public ApiResponse<AuthLoginResDTO> login(
+            @RequestBody @Valid AuthLoginReqDTO request
+    ) {
+        AuthLoginResDTO result = authService.login(request);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
 }

--- a/src/main/java/com/kwcapstone/server/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/com/kwcapstone/server/domain/auth/converter/AuthConverter.java
@@ -1,0 +1,31 @@
+package com.kwcapstone.server.domain.auth.converter;
+
+import com.kwcapstone.server.domain.auth.dto.response.AuthLoginResDTO;
+import com.kwcapstone.server.domain.auth.dto.response.AuthSignUpResDTO;
+import com.kwcapstone.server.domain.member.entity.Member;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuthConverter {
+    // 회원가입 응답
+    public static AuthSignUpResDTO toSignUpResDTO(Member member) {
+        return new AuthSignUpResDTO(
+                member.getId(),
+                member.getEmail(),
+                member.getNickname()
+        );
+    }
+
+    // 로그인 응답
+    public static AuthLoginResDTO toLoginResDTO(String accessToken, Member member) {
+        return new AuthLoginResDTO(
+                accessToken,
+                new AuthLoginResDTO.MemberInfo(
+                        member.getId(),
+                        member.getEmail(),
+                        member.getNickname()
+                )
+        );
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/auth/dto/request/AuthLoginReqDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/auth/dto/request/AuthLoginReqDTO.java
@@ -1,0 +1,15 @@
+package com.kwcapstone.server.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class AuthLoginReqDTO { // 로그인 요청 DTO
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/kwcapstone/server/domain/auth/dto/request/AuthSignUpReqDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/auth/dto/request/AuthSignUpReqDTO.java
@@ -1,0 +1,18 @@
+package com.kwcapstone.server.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class AuthSignUpReqDTO { // 회원가입 요청 DTO
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String password;
+
+    @NotBlank
+    private String nickname;
+}

--- a/src/main/java/com/kwcapstone/server/domain/auth/dto/response/AuthLoginResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/auth/dto/response/AuthLoginResDTO.java
@@ -1,0 +1,19 @@
+package com.kwcapstone.server.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthLoginResDTO { // 로그인 응답 DTO
+    private String accessToken;
+    private MemberInfo member;
+
+    @Getter
+    @AllArgsConstructor
+    public static class MemberInfo {
+        private Long memberId;
+        private String email;
+        private String nickname;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/auth/dto/response/AuthReissueResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/auth/dto/response/AuthReissueResDTO.java
@@ -1,0 +1,10 @@
+package com.kwcapstone.server.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthReissueResDTO { // Access Token 재발급 응답 DTO
+    private String accessToken;
+}

--- a/src/main/java/com/kwcapstone/server/domain/auth/dto/response/AuthSignUpResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/auth/dto/response/AuthSignUpResDTO.java
@@ -1,0 +1,12 @@
+package com.kwcapstone.server.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthSignUpResDTO { // 회원가입 응답 DTO
+    private Long memberId;
+    private String email;
+    private String nickname;
+}

--- a/src/main/java/com/kwcapstone/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kwcapstone/server/domain/auth/service/AuthService.java
@@ -1,0 +1,11 @@
+package com.kwcapstone.server.domain.auth.service;
+
+import com.kwcapstone.server.domain.auth.dto.request.AuthLoginReqDTO;
+import com.kwcapstone.server.domain.auth.dto.request.AuthSignUpReqDTO;
+import com.kwcapstone.server.domain.auth.dto.response.AuthLoginResDTO;
+import com.kwcapstone.server.domain.auth.dto.response.AuthSignUpResDTO;
+
+public interface AuthService {
+    AuthSignUpResDTO signup(AuthSignUpReqDTO request);
+    AuthLoginResDTO login(AuthLoginReqDTO request);
+}

--- a/src/main/java/com/kwcapstone/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kwcapstone/server/domain/auth/service/AuthService.java
@@ -3,9 +3,12 @@ package com.kwcapstone.server.domain.auth.service;
 import com.kwcapstone.server.domain.auth.dto.request.AuthLoginReqDTO;
 import com.kwcapstone.server.domain.auth.dto.request.AuthSignUpReqDTO;
 import com.kwcapstone.server.domain.auth.dto.response.AuthLoginResDTO;
+import com.kwcapstone.server.domain.auth.dto.response.AuthReissueResDTO;
 import com.kwcapstone.server.domain.auth.dto.response.AuthSignUpResDTO;
 
 public interface AuthService {
     AuthSignUpResDTO signup(AuthSignUpReqDTO request);
     AuthLoginResDTO login(AuthLoginReqDTO request);
+    AuthReissueResDTO reissue(String refreshToken);
+    void logout();
 }

--- a/src/main/java/com/kwcapstone/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kwcapstone/server/domain/auth/service/AuthService.java
@@ -3,12 +3,23 @@ package com.kwcapstone.server.domain.auth.service;
 import com.kwcapstone.server.domain.auth.dto.request.AuthLoginReqDTO;
 import com.kwcapstone.server.domain.auth.dto.request.AuthSignUpReqDTO;
 import com.kwcapstone.server.domain.auth.dto.response.AuthLoginResDTO;
-import com.kwcapstone.server.domain.auth.dto.response.AuthReissueResDTO;
 import com.kwcapstone.server.domain.auth.dto.response.AuthSignUpResDTO;
 
 public interface AuthService {
     AuthSignUpResDTO signup(AuthSignUpReqDTO request);
-    AuthLoginResDTO login(AuthLoginReqDTO request);
-    AuthReissueResDTO reissue(String refreshToken);
+    LoginTokens login(AuthLoginReqDTO request);
+    ReissueTokens reissue(String refreshToken);
     void logout();
+
+    record LoginTokens(
+            AuthLoginResDTO body,
+            String refreshToken,
+            long refreshMaxAgeSeconds
+    ) {}
+
+    record ReissueTokens(
+            String accessToken,
+            String refreshToken,
+            long refreshMaxAgeSeconds
+    ) {}
 }

--- a/src/main/java/com/kwcapstone/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/auth/service/AuthServiceImpl.java
@@ -4,7 +4,6 @@ import com.kwcapstone.server.domain.auth.converter.AuthConverter;
 import com.kwcapstone.server.domain.auth.dto.request.AuthLoginReqDTO;
 import com.kwcapstone.server.domain.auth.dto.request.AuthSignUpReqDTO;
 import com.kwcapstone.server.domain.auth.dto.response.AuthLoginResDTO;
-import com.kwcapstone.server.domain.auth.dto.response.AuthReissueResDTO;
 import com.kwcapstone.server.domain.auth.dto.response.AuthSignUpResDTO;
 import com.kwcapstone.server.domain.member.entity.Member;
 import com.kwcapstone.server.domain.member.repository.MemberRepository;
@@ -52,7 +51,7 @@ public class AuthServiceImpl implements AuthService {
 
     // 로그인
     @Override
-    public AuthLoginResDTO login(AuthLoginReqDTO request) {
+    public LoginTokens login(AuthLoginReqDTO request) {
         // 이메일로 회원 조회
         Member member = memberRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED)); // TODO: 에러코드 구체화하기
@@ -62,24 +61,33 @@ public class AuthServiceImpl implements AuthService {
             throw new CustomException(ErrorCode.UNAUTHORIZED); // TODO: 에러코드 구체화하기
         }
 
-        // Access Token 생성
         String accessToken = jwtProvider.createAccessToken(member.getId(), member.getEmail());
-
-        // Refresh Token 생성
         String refreshToken = jwtProvider.createRefreshToken(member.getId(), member.getEmail());
 
-        // Refresh Token DB 저장
-        member.updateRefreshToken(
-                refreshToken,
-                LocalDateTime.now().plusSeconds(jwtProvider.getRefreshExpireMs() / 1000)
-        );
+        // DB에 저장할 Refresh Token 만료 시각 계산
+        LocalDateTime refreshExpiredAt = LocalDateTime.now().plusSeconds(jwtProvider.getRefreshExpireMs() / 1000);
 
-        return AuthConverter.toLoginResDTO(accessToken, member);
+        // Refresh Token DB 저장
+        member.updateRefreshToken(refreshToken, refreshExpiredAt);
+
+        // 쿠키 만료 시간용 값 계산
+        long refreshMaxAgeSeconds = jwtProvider.getRefreshExpireMs() / 1000;
+
+        AuthLoginResDTO body = AuthConverter.toLoginResDTO(accessToken, member);
+
+        return new LoginTokens(body, refreshToken, refreshMaxAgeSeconds);
     }
 
+    /**
+     * Refresh Token을 받아
+     * 새로운 Access Token, 새로운 Refresh Token을 발급하는 메서드
+     * 현재 구조는 Refresh Token Rotation까지 포함된 구조
+     */
     @Override
-    public AuthReissueResDTO reissue(String refreshToken) {
-        refreshToken = jwtProvider.resolveToken(refreshToken);
+    public ReissueTokens reissue(String refreshToken) {
+        if (refreshToken == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
 
         // Refresh Token 검증
         if (!jwtProvider.validateRefreshToken(refreshToken)) {
@@ -91,7 +99,7 @@ public class AuthServiceImpl implements AuthService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 
-        // DB Refresh Token 검증
+        // DB Refresh Token과 비교
         if (!refreshToken.equals(member.getRefreshToken())) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
@@ -101,10 +109,22 @@ public class AuthServiceImpl implements AuthService {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
-        // 새로운 Access Token 발급
+        // 새로운 Access Token, Refresh Token 발급 (Refresh Token Rotation)
         String newAccessToken = jwtProvider.createAccessToken(member.getId(), member.getEmail());
+        String newRefreshToken = jwtProvider.createRefreshToken(member.getId(), member.getEmail());
 
-        return new AuthReissueResDTO(newAccessToken);
+        LocalDateTime newExpiredAt = LocalDateTime.now().plusSeconds(jwtProvider.getRefreshExpireMs() / 1000);
+
+        // DB에 현재 저장된 Refresh Token이 기존 Refresh Token과 같을 때만 교체 (새 Refresh Token으로 교체)
+        int updated = memberRepository.rotateRefreshToken(memberId, refreshToken, newRefreshToken, newExpiredAt);
+
+        if (updated == 0) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        long refreshMaxAgeSeconds = jwtProvider.getRefreshExpireMs() / 1000;
+
+        return new ReissueTokens(newAccessToken, newRefreshToken, refreshMaxAgeSeconds);
     }
 
     @Override

--- a/src/main/java/com/kwcapstone/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/auth/service/AuthServiceImpl.java
@@ -4,11 +4,13 @@ import com.kwcapstone.server.domain.auth.converter.AuthConverter;
 import com.kwcapstone.server.domain.auth.dto.request.AuthLoginReqDTO;
 import com.kwcapstone.server.domain.auth.dto.request.AuthSignUpReqDTO;
 import com.kwcapstone.server.domain.auth.dto.response.AuthLoginResDTO;
+import com.kwcapstone.server.domain.auth.dto.response.AuthReissueResDTO;
 import com.kwcapstone.server.domain.auth.dto.response.AuthSignUpResDTO;
 import com.kwcapstone.server.domain.member.entity.Member;
 import com.kwcapstone.server.domain.member.repository.MemberRepository;
 import com.kwcapstone.server.global.apiPayload.exception.CustomException;
 import com.kwcapstone.server.global.apiPayload.response.ErrorCode;
+import com.kwcapstone.server.global.security.SecurityUtil;
 import com.kwcapstone.server.global.security.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -73,5 +75,45 @@ public class AuthServiceImpl implements AuthService {
         );
 
         return AuthConverter.toLoginResDTO(accessToken, member);
+    }
+
+    @Override
+    public AuthReissueResDTO reissue(String refreshToken) {
+        refreshToken = jwtProvider.resolveToken(refreshToken);
+
+        // Refresh Token 검증
+        if (!jwtProvider.validateRefreshToken(refreshToken)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        Long memberId = jwtProvider.getMemberId(refreshToken);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+        // DB Refresh Token 검증
+        if (!refreshToken.equals(member.getRefreshToken())) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // DB Refresh Token 만료 검사
+        if (member.getRefreshTokenExpiredAt().isBefore(LocalDateTime.now())) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 새로운 Access Token 발급
+        String newAccessToken = jwtProvider.createAccessToken(member.getId(), member.getEmail());
+
+        return new AuthReissueResDTO(newAccessToken);
+    }
+
+    @Override
+    public void logout() {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+        member.clearRefreshToken();
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,77 @@
+package com.kwcapstone.server.domain.auth.service;
+
+import com.kwcapstone.server.domain.auth.converter.AuthConverter;
+import com.kwcapstone.server.domain.auth.dto.request.AuthLoginReqDTO;
+import com.kwcapstone.server.domain.auth.dto.request.AuthSignUpReqDTO;
+import com.kwcapstone.server.domain.auth.dto.response.AuthLoginResDTO;
+import com.kwcapstone.server.domain.auth.dto.response.AuthSignUpResDTO;
+import com.kwcapstone.server.domain.member.entity.Member;
+import com.kwcapstone.server.domain.member.repository.MemberRepository;
+import com.kwcapstone.server.global.apiPayload.exception.CustomException;
+import com.kwcapstone.server.global.apiPayload.response.ErrorCode;
+import com.kwcapstone.server.global.security.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthServiceImpl implements AuthService {
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    // 회원가입
+    @Override
+    public AuthSignUpResDTO signup(AuthSignUpReqDTO request) {
+        // 이메일 중복 검사
+        if (memberRepository.existsByEmail(request.getEmail())) {
+            throw new CustomException(ErrorCode.DUPLICATE_RESOURCE);
+        }
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        // Member 생성
+        Member member = Member.builder()
+                .email(request.getEmail())
+                .password(encodedPassword)
+                .nickname(request.getNickname())
+                .build();
+
+        memberRepository.save(member);
+
+        return AuthConverter.toSignUpResDTO(member);
+    }
+
+    // 로그인
+    @Override
+    public AuthLoginResDTO login(AuthLoginReqDTO request) {
+        // 이메일로 회원 조회
+        Member member = memberRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED)); // TODO: 에러코드 구체화하기
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED); // TODO: 에러코드 구체화하기
+        }
+
+        // Access Token 생성
+        String accessToken = jwtProvider.createAccessToken(member.getId(), member.getEmail());
+
+        // Refresh Token 생성
+        String refreshToken = jwtProvider.createRefreshToken(member.getId(), member.getEmail());
+
+        // Refresh Token DB 저장
+        member.updateRefreshToken(
+                refreshToken,
+                LocalDateTime.now().plusSeconds(jwtProvider.getRefreshExpireMs() / 1000)
+        );
+
+        return AuthConverter.toLoginResDTO(accessToken, member);
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/member/entity/Member.java
+++ b/src/main/java/com/kwcapstone/server/domain/member/entity/Member.java
@@ -1,0 +1,43 @@
+package com.kwcapstone.server.domain.member.entity;
+
+import com.kwcapstone.server.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "member", uniqueConstraints = {@UniqueConstraint(name = "uk_member_email", columnNames = "email")})
+public class Member extends BaseEntity {
+    @Column(nullable = false, length = 30)
+    private String email;
+
+    @Column(nullable = false, length = 30)
+    private String password;
+
+    @Column(nullable = false, length = 20)
+    private String nickname;
+
+    @Column(name = "refresh_token", length = 512)
+    private String refreshToken;
+
+    @Column(name = "refresh_token_expired_at")
+    private LocalDateTime refreshTokenExpiredAt;
+
+    public void updateRefreshToken(String token, LocalDateTime expiredAt) {
+        this.refreshToken = token;
+        this.refreshTokenExpiredAt = expiredAt;
+    }
+
+    public void clearRefreshToken() {
+        this.refreshToken = null;
+        this.refreshTokenExpiredAt = null;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/member/entity/Member.java
+++ b/src/main/java/com/kwcapstone/server/domain/member/entity/Member.java
@@ -19,7 +19,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false, length = 30)
     private String email;
 
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false, length = 200)
     private String password;
 
     @Column(nullable = false, length = 20)

--- a/src/main/java/com/kwcapstone/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/member/repository/MemberRepository.java
@@ -2,8 +2,12 @@ package com.kwcapstone.server.domain.member.repository;
 
 import com.kwcapstone.server.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
@@ -13,4 +17,19 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     // email로 Member를 조회하는 메서드
     Optional<Member> findByEmail(String email);
+
+    @Modifying // UPDATE 쿼리
+    @Query("""
+    update Member m
+        set m.refreshToken = :newToken,
+            m.refreshTokenExpiredAt = :newExpiredAt
+    where m.id = :memberId
+        and m.refreshToken = :oldToken
+    """)
+    int rotateRefreshToken(
+            @Param("memberId") Long memberId,
+            @Param("oldToken") String oldToken,
+            @Param("newToken") String newToken,
+            @Param("newExpiredAt") LocalDateTime newExpiredAt
+    );
 }

--- a/src/main/java/com/kwcapstone/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/member/repository/MemberRepository.java
@@ -1,0 +1,16 @@
+package com.kwcapstone.server.domain.member.repository;
+
+import com.kwcapstone.server.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    // 해당 이메일을 가진 회원이 존재하는지 확인하는 메서드
+    boolean existsByEmail(String email);
+
+    // email로 Member를 조회하는 메서드
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/kwcapstone/server/global/config/CorsConfig.java
+++ b/src/main/java/com/kwcapstone/server/global/config/CorsConfig.java
@@ -1,0 +1,30 @@
+package com.kwcapstone.server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOrigins(List.of("http://localhost:3000"));
+        config.setAllowedMethods(List.of("*"));
+        config.setAllowedHeaders(List.of("*"));
+
+        // 브라우저가 쿠키를 포함한 요청을 보낼 수 있도록 허용함
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/global/security/AuthPrincipal.java
+++ b/src/main/java/com/kwcapstone/server/global/security/AuthPrincipal.java
@@ -1,0 +1,11 @@
+package com.kwcapstone.server.global.security;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthPrincipal { // JWT 인증 후 SecurityContext에 들어가는 로그인 사용자 정보
+    private final Long memberId;
+    private final String email;
+}

--- a/src/main/java/com/kwcapstone/server/global/security/SecurityConfig.java
+++ b/src/main/java/com/kwcapstone/server/global/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.kwcapstone.server.global.security.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -25,6 +26,8 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
+
+                .cors(Customizer.withDefaults())
 
                 // URL 접근 권한 설정
                 .authorizeHttpRequests(auth -> auth

--- a/src/main/java/com/kwcapstone/server/global/security/SecurityConfig.java
+++ b/src/main/java/com/kwcapstone/server/global/security/SecurityConfig.java
@@ -1,0 +1,56 @@
+package com.kwcapstone.server.global.security;
+
+import com.kwcapstone.server.global.security.jwt.JwtAuthenticationFilter;
+import com.kwcapstone.server.global.security.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+    private final JwtProvider jwtProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // 기존 보안 기능 비활성화
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+
+                // URL 접근 권한 설정
+                .authorizeHttpRequests(auth -> auth
+                        // PUBLIC
+                        .requestMatchers("/auth/**").permitAll()
+                        // 나머지
+                        .anyRequest().authenticated() // 현재는 JWT 인증 필요
+                )
+
+                /**
+                 * JWT 인증 필터 등록
+                 * UsernamePasswordAuthenticationFilter 이전에 실행
+                 * Authorization: Bearer {token} 헤더에서 JWT 추출
+                 * 유효한 경우 SecurityContext에 AuthPrincipal 세팅
+                 * 즉, 로그인 사용자 등록
+                 */
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtProvider),
+                        UsernamePasswordAuthenticationFilter.class
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/kwcapstone/server/global/security/SecurityConfig.java
+++ b/src/main/java/com/kwcapstone/server/global/security/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                         // PUBLIC
                         .requestMatchers("/auth/**").permitAll()
                         // 나머지
-                        .anyRequest().authenticated() // 현재는 JWT 인증 필요
+                        .anyRequest().permitAll()
                 )
 
                 /**

--- a/src/main/java/com/kwcapstone/server/global/security/SecurityUtil.java
+++ b/src/main/java/com/kwcapstone/server/global/security/SecurityUtil.java
@@ -1,0 +1,34 @@
+package com.kwcapstone.server.global.security;
+
+import com.kwcapstone.server.global.apiPayload.exception.CustomException;
+import com.kwcapstone.server.global.apiPayload.response.ErrorCode;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtil {
+    // 현재 로그인한 사용자 정보 조회
+    public static Long getCurrentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 인증 객체 자체가 없거나 인증이 안 된 경우
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 익명 사용자(로그인 하지 않은 상태)일 경우
+        if (authentication instanceof AnonymousAuthenticationToken) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 현재 로그인한 사용자 정보
+        Object principal = authentication.getPrincipal();
+
+        // JWT에서 추출한 memberId 반환
+        if (principal instanceof AuthPrincipal authPrincipal) {
+            return authPrincipal.getMemberId();
+        }
+
+        throw new CustomException(ErrorCode.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/kwcapstone/server/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kwcapstone/server/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package com.kwcapstone.server.global.security.jwt;
+
+import com.kwcapstone.server.global.security.AuthPrincipal;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    // 요청마다 JWT 검사(인증)
+    private final JwtProvider jwtProvider;
+
+    /**
+     * 요청이 들어올 때마다 실행되는 로직
+     * 1. Authorization 헤더 확인
+     * 2. Bearer 토큰 추출
+     * 3. JWT 검증
+     * 4. 사용자 정보 추출
+     * 5. Authentication 생성
+     * 6. SecurityContext 저장
+     */
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+
+            if (jwtProvider.validateAccessToken(token)) {
+                Long memberId = jwtProvider.getMemberId(token);
+                String email = jwtProvider.getEmail(token);
+
+                AuthPrincipal principal = new AuthPrincipal(memberId, email);
+
+                // Authentication 객체 생성
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(principal, null, Collections.emptyList());
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/kwcapstone/server/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/kwcapstone/server/global/security/jwt/JwtProvider.java
@@ -29,7 +29,7 @@ public class JwtProvider {
 
     // 로그인 성공 시 Access Token 생성
     public String createAccessToken(Long memberId, String email) {
-        Long now = System.currentTimeMillis(); // 현재 시간
+        long now = System.currentTimeMillis(); // 현재 시간
 
         return Jwts.builder() // JWT 생성 시작
                 .claim("memberId", memberId) // JWT payload에 memberId 저장
@@ -43,7 +43,7 @@ public class JwtProvider {
 
     // Refresh Token 생성
     public String createRefreshToken(Long memberId, String email) {
-        Long now = System.currentTimeMillis();
+        long now = System.currentTimeMillis();
 
         return Jwts.builder()
                 .claim("memberId", memberId)
@@ -79,6 +79,27 @@ public class JwtProvider {
         } catch (JwtException e) {
             return false;
         }
+    }
+
+    // Refresh Token 검증
+    public boolean validateRefreshToken(String token) {
+        try {
+            Claims claims = parseClaims(token);
+
+            // Refresh Token인지 확인
+            return "refresh".equals(claims.get("type"));
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+
+    // "Bearer " 제거 후 JWT 토큰 반환
+    public String resolveToken(String token) {
+        if (token != null && token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+
+        return token;
     }
 
     private Claims parseClaims(String token) {

--- a/src/main/java/com/kwcapstone/server/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/kwcapstone/server/global/security/jwt/JwtProvider.java
@@ -65,6 +65,10 @@ public class JwtProvider {
         return parseClaims(token).get("email", String.class);
     }
 
+    public Long getRefreshExpireMs() {
+        return refreshExpireMs;
+    }
+
     // Access Token 검증
     public boolean validateAccessToken(String token) {
         try {

--- a/src/main/java/com/kwcapstone/server/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/kwcapstone/server/global/security/jwt/JwtProvider.java
@@ -1,0 +1,87 @@
+package com.kwcapstone.server.global.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+    private final SecretKey secretKey; // 암호화 키
+    private final Long accessExpireMs; // Access Token 만료 시간
+    private final Long refreshExpireMs; // Refresh Token 만료 시간
+
+    public JwtProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-expire}") Long accessExpireMs,
+            @Value("${jwt.refresh-expire}") Long refreshExpireMs
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+        this.accessExpireMs = accessExpireMs;
+        this.refreshExpireMs = refreshExpireMs;
+    }
+
+    // 로그인 성공 시 Access Token 생성
+    public String createAccessToken(Long memberId, String email) {
+        Long now = System.currentTimeMillis(); // 현재 시간
+
+        return Jwts.builder() // JWT 생성 시작
+                .claim("memberId", memberId) // JWT payload에 memberId 저장
+                .claim("email", email) // JWT payload에 email 저장
+                .claim("type", "access") // Token 종류 표시(access)
+                .setIssuedAt(new Date(now)) // 토큰 발급 시간(메서드 deprecated)
+                .setExpiration(new Date(now + accessExpireMs)) // 토큰 만료 시간(메서드 deprecated)
+                .signWith(secretKey) // JWT 서명 생성(Header + Payload -> Signature 생성)
+                .compact(); // JWT 문자열 생성
+    }
+
+    // Refresh Token 생성
+    public String createRefreshToken(Long memberId, String email) {
+        Long now = System.currentTimeMillis();
+
+        return Jwts.builder()
+                .claim("memberId", memberId)
+                .claim("email", email)
+                .claim("type", "refresh") // Token 종류 표시(refresh)
+                .setIssuedAt(new Date(now))
+                .setExpiration(new Date(now + refreshExpireMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // JWT에서 memberId 추출
+    public Long getMemberId(String token) {
+        return parseClaims(token).get("memberId", Long.class);
+    }
+
+    // JWT에서 email 추출
+    public String getEmail(String token) {
+        return parseClaims(token).get("email", String.class);
+    }
+
+    // Access Token 검증
+    public boolean validateAccessToken(String token) {
+        try {
+            Claims claims = parseClaims(token);
+
+            // Access Token인지 확인
+            return "access".equals(claims.get("type"));
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey) // 서명 검증
+                .build()
+                .parseSignedClaims(token)
+                .getPayload(); // JWT -> Claims
+    }
+}

--- a/src/main/java/com/kwcapstone/server/global/util/CookieUtil.java
+++ b/src/main/java/com/kwcapstone/server/global/util/CookieUtil.java
@@ -1,0 +1,35 @@
+package com.kwcapstone.server.global.util;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+    // refreshToken 쿠키를 생성해서 응답에 추가
+    public void addRefreshTokenCookie(HttpServletResponse response, String refreshToken, long maxAgeSeconds) {
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true) // JS에서 접근 불가
+                .secure(false) // 개발 환경에서는 HTTP도 허용
+                .path("/") // 전체 경로에서 쿠키 사용 가능
+                .sameSite("Lax") // 같은 사이트 요청에서는 정상 전송
+                .maxAge(maxAgeSeconds) // 쿠키 만료 시간 설정
+                .build();
+
+        // ex) Set-Cookie: refreshToken=...; Path=/; HttpOnly; SameSite=Lax; Max-Age=...
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    // 브라우저에 저장된 refreshToken 쿠키 삭제 (로그아웃)
+    public void clearRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .sameSite("Lax")
+                .maxAge(0)
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,6 +22,11 @@ spring:
         format_sql: true
         default_batch_fetch_size: 1000
 
+jwt:
+  secret: ${JWT_SECRET}
+  access-expire: ${JWT_ACCESS_TOKEN_EXPIRE_MS}
+  refresh-expire: ${JWT_REFRESH_TOKEN_EXPIRE_MS}
+
 logging:
   level:
     root: INFO


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #3

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- JWT 기반 인증 인프라 구성
- Member 도메인 Entity, Repository 구현
- Spring Security 설정 및 JWT 인증 필터 추가
- Auth 도메인 DTO, Converter, Service, Controller 구현
- 회원가입 API 구현
- 로그인 API 구현
- Access Token 재발급 API 구현
- 로그아웃 API 구현
- Refresh Token을 HttpOnly Cookie로 처리하도록 반영

로그인 시 Access Token은 응답 body로 반환되고, Refresh Token은 Cookie로 설정됨
Access Token 재발급 시 Cookie에 담긴 Refresh Token을 통해 새로운 Access Token 발급
로그아웃 시 DB의 Refresh Token과 Cookie 삭제


## 🧪 테스트 결과
> Apidog 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

[회원가입]
![signup-1](https://github.com/user-attachments/assets/32a6c09d-4d1d-4129-b65d-45eb4f42f572)

![signup-2](https://github.com/user-attachments/assets/5a9a17a1-8295-465c-ac93-29e94ec5519e)

![signup-3](https://github.com/user-attachments/assets/4e4a5a6a-7957-477a-bea0-fd1f4657f18e)

![signup-4](https://github.com/user-attachments/assets/879d5a4b-9ebd-46a2-8e4f-e6bcb26ded5e)

<br>

[로그인]
![login-1](https://github.com/user-attachments/assets/04664d1d-8adf-455f-8afe-631eb20c3832)

![login-2](https://github.com/user-attachments/assets/d7b4ba00-b064-4e6f-8f07-d9ebffd8bd9d)

<br>

[액세스 토큰 재발급]
![reissue](https://github.com/user-attachments/assets/f5950e7c-56b5-4d64-bd1e-268504a08371)

<br>

[로그아웃]
![logout-1](https://github.com/user-attachments/assets/90a9d02a-3777-4436-bf57-3a920d4ba9aa)

![logout-2](https://github.com/user-attachments/assets/834ffafb-ff0c-4446-939c-df285d8c6256)

<br>

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

- 현재 Refresh Token은 HttpOnly Cookie 기반으로 처리됨
- Access Token은 응답 body로 반환하고, 이후 인증이 필요한 요청에서 Authorization 헤더로 사용
- 개발 환경에서의 CORS 및 쿠키 전송을 고려한 설정 추가
- 인증이 필요한 API 범위 확장 시 SecurityConfig의 인가 정책 추가 조정 필요