### PR TITLE
[Feat] 나만의 문장 노트 CRUD API 구현 

### DIFF
--- a/src/main/java/com/kwcapstone/server/domain/mysentence/controller/MySentenceCommandController.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/controller/MySentenceCommandController.java
@@ -2,15 +2,14 @@ package com.kwcapstone.server.domain.mysentence.controller;
 
 import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceCreateReqDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceCreateResDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceDeleteResDTO;
 import com.kwcapstone.server.domain.mysentence.service.MySentenceCommandService;
 import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
 import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,12 +19,25 @@ public class MySentenceCommandController {
     private final MySentenceCommandService mySentenceCommandService;
 
     // 나만의 문장 생성 API
+    @Operation(summary = "나만의 문장 생성")
     @PostMapping
     public ApiResponse<MySentenceCreateResDTO> createMySentence(
             @RequestBody @Valid MySentenceCreateReqDTO request
     ) {
         MySentenceCreateResDTO result =
                 mySentenceCommandService.createMySentence(request);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    // 나만의 문장 삭제 API
+    @Operation(summary = "나만의 문장 삭제")
+    @DeleteMapping("/{sentenceId}")
+    public ApiResponse<MySentenceDeleteResDTO> deleteMySentence(
+            @PathVariable Long sentenceId
+    ) {
+        MySentenceDeleteResDTO result =
+                mySentenceCommandService.deleteMySentence(sentenceId);
 
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/controller/MySentenceCommandController.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/controller/MySentenceCommandController.java
@@ -1,0 +1,32 @@
+package com.kwcapstone.server.domain.mysentence.controller;
+
+import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceCreateReqDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceCreateResDTO;
+import com.kwcapstone.server.domain.mysentence.service.MySentenceCommandService;
+import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
+import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/warmups/my-sentences")
+public class MySentenceCommandController {
+
+    private final MySentenceCommandService mySentenceCommandService;
+
+    // 나만의 문장 생성 API
+    @PostMapping
+    public ApiResponse<MySentenceCreateResDTO> createMySentence(
+            @RequestBody @Valid MySentenceCreateReqDTO request
+    ) {
+        MySentenceCreateResDTO result =
+                mySentenceCommandService.createMySentence(request);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/controller/MySentenceQueryController.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/controller/MySentenceQueryController.java
@@ -1,0 +1,26 @@
+package com.kwcapstone.server.domain.mysentence.controller;
+
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceListResDTO;
+import com.kwcapstone.server.domain.mysentence.service.MySentenceQueryService;
+import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
+import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/warmups/my-sentences")
+public class MySentenceQueryController {
+
+    private final MySentenceQueryService mySentenceQueryService;
+
+    @Operation(summary = "저장된 문장 목록 조회")
+    @GetMapping
+    public ApiResponse<MySentenceListResDTO> getMySentences() {
+        MySentenceListResDTO result = mySentenceQueryService.getMySentences();
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/controller/MySentenceQueryController.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/controller/MySentenceQueryController.java
@@ -1,5 +1,6 @@
 package com.kwcapstone.server.domain.mysentence.controller;
 
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceDetailResDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceListResDTO;
 import com.kwcapstone.server.domain.mysentence.service.MySentenceQueryService;
 import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
@@ -7,6 +8,7 @@ import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,10 +19,23 @@ public class MySentenceQueryController {
 
     private final MySentenceQueryService mySentenceQueryService;
 
+    // 저장된 문장 목록 조회 API
     @Operation(summary = "저장된 문장 목록 조회")
     @GetMapping
     public ApiResponse<MySentenceListResDTO> getMySentences() {
         MySentenceListResDTO result = mySentenceQueryService.getMySentences();
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    // 선택된 문장 상세 조회 API
+    @Operation (summary = "선택된 문장 상세 조회")
+    @GetMapping("/{sentenceId}")
+    public ApiResponse<MySentenceDetailResDTO> getMySentenceDetail(
+            @PathVariable Long sentenceId
+    ) {
+        MySentenceDetailResDTO result =
+                mySentenceQueryService.getMySentenceDetail(sentenceId);
+
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/converter/MySentenceConverter.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/converter/MySentenceConverter.java
@@ -3,6 +3,7 @@ package com.kwcapstone.server.domain.mysentence.converter;
 import com.kwcapstone.server.domain.member.entity.Member;
 import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceCreateReqDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceCreateResDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceDetailResDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceListResDTO;
 import com.kwcapstone.server.domain.mysentence.entity.MySentence;
 
@@ -39,6 +40,13 @@ public class MySentenceConverter {
                 mySentences.stream()
                         .map(MySentenceConverter::toMySentenceInfo)
                         .toList()
+        );
+    }
+
+    public static MySentenceDetailResDTO toDetailResponse(MySentence mySentence) {
+        return new MySentenceDetailResDTO(
+                mySentence.getId(),
+                mySentence.getSentenceContent()
         );
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/converter/MySentenceConverter.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/converter/MySentenceConverter.java
@@ -3,7 +3,10 @@ package com.kwcapstone.server.domain.mysentence.converter;
 import com.kwcapstone.server.domain.member.entity.Member;
 import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceCreateReqDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceCreateResDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceListResDTO;
 import com.kwcapstone.server.domain.mysentence.entity.MySentence;
+
+import java.util.List;
 
 public class MySentenceConverter {
 
@@ -21,6 +24,21 @@ public class MySentenceConverter {
         return new MySentenceCreateResDTO(
                 mySentence.getId(),
                 mySentence.getSentenceContent()
+        );
+    }
+
+    public static MySentenceListResDTO.MySentenceInfo toMySentenceInfo(MySentence mySentence) {
+        return new MySentenceListResDTO.MySentenceInfo(
+                mySentence.getId(),
+                mySentence.getSentenceContent()
+        );
+    }
+
+    public static MySentenceListResDTO toListResponse(List<MySentence> mySentences) {
+        return new MySentenceListResDTO(
+                mySentences.stream()
+                        .map(MySentenceConverter::toMySentenceInfo)
+                        .toList()
         );
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/converter/MySentenceConverter.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/converter/MySentenceConverter.java
@@ -1,0 +1,26 @@
+package com.kwcapstone.server.domain.mysentence.converter;
+
+import com.kwcapstone.server.domain.member.entity.Member;
+import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceCreateReqDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceCreateResDTO;
+import com.kwcapstone.server.domain.mysentence.entity.MySentence;
+
+public class MySentenceConverter {
+
+    private MySentenceConverter() {
+    }
+
+    public static MySentence toMySentence(MySentenceCreateReqDTO request, Member member) {
+        return MySentence.builder()
+                .member(member)
+                .sentenceContent(request.getSentenceContent().trim())
+                .build();
+    }
+
+    public static MySentenceCreateResDTO toCreateResponse(MySentence mySentence) {
+        return new MySentenceCreateResDTO(
+                mySentence.getId(),
+                mySentence.getSentenceContent()
+        );
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/dto/request/MySentenceCreateReqDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/dto/request/MySentenceCreateReqDTO.java
@@ -1,7 +1,5 @@
 package com.kwcapstone.server.domain.mysentence.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/dto/request/MySentenceCreateReqDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/dto/request/MySentenceCreateReqDTO.java
@@ -1,0 +1,12 @@
+package com.kwcapstone.server.domain.mysentence.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MySentenceCreateReqDTO {
+    private String sentenceContent;
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/MySentenceCreateResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/MySentenceCreateResDTO.java
@@ -1,0 +1,11 @@
+package com.kwcapstone.server.domain.mysentence.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MySentenceCreateResDTO {
+    private Long sentenceId;
+    private String sentenceContent;
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/MySentenceDeleteResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/MySentenceDeleteResDTO.java
@@ -1,0 +1,10 @@
+package com.kwcapstone.server.domain.mysentence.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MySentenceDeleteResDTO {
+    private Long sentenceId;
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/MySentenceDetailResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/MySentenceDetailResDTO.java
@@ -1,0 +1,11 @@
+package com.kwcapstone.server.domain.mysentence.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MySentenceDetailResDTO {
+    private Long sentenceId;
+    private String sentenceContent;
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/MySentenceListResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/MySentenceListResDTO.java
@@ -1,0 +1,19 @@
+package com.kwcapstone.server.domain.mysentence.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MySentenceListResDTO {
+    private List<MySentenceInfo> sentences;
+
+    @Getter
+    @AllArgsConstructor
+    public static class MySentenceInfo{
+        private Long sentenceId;
+        private String sentenceContent;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/entity/MySentence.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/entity/MySentence.java
@@ -1,0 +1,42 @@
+package com.kwcapstone.server.domain.mysentence.entity;
+
+import com.kwcapstone.server.domain.member.entity.Member;
+import com.kwcapstone.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "my_sentence")
+public class MySentence extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "sentence_content", nullable = false, length = 300)
+    private String sentenceContent;
+
+    @Column(name = "ai_audio_key", length = 500)
+    private String aiAudioKey;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public void updateAiAudioKey(String aiAudioKey) {
+        this.aiAudioKey = aiAudioKey;
+    }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/exception/code/MySentenceErrorCode.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/exception/code/MySentenceErrorCode.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum MySentenceErrorCode implements BaseCode {
 
     EMPTY_SENTENCE_CONTENT(HttpStatus.BAD_REQUEST, "WARMUP_400_1", "문장 내용이 비어있습니다."),
-    SENTENCE_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "WARMUP_400_2", "문장 길이를 초과했습니다.")
+    SENTENCE_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "WARMUP_400_2", "문장 길이를 초과했습니다."),
+    MY_SENTENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "WARMUP404", "존재하지 않거나 이미 삭제된 문장입니다."),
+    MY_SENTENCE_FORBIDDEN(HttpStatus.FORBIDDEN, "WARMUP403", "본인의 문장이 아니어서 삭제할 수 없습니다.")
     ;
 
 

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/exception/code/MySentenceErrorCode.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/exception/code/MySentenceErrorCode.java
@@ -1,0 +1,20 @@
+package com.kwcapstone.server.domain.mysentence.exception.code;
+
+import com.kwcapstone.server.global.apiPayload.response.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MySentenceErrorCode implements BaseCode {
+
+    EMPTY_SENTENCE_CONTENT(HttpStatus.BAD_REQUEST, "WARMUP_400_1", "문장 내용이 비어있습니다."),
+    SENTENCE_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "WARMUP_400_2", "문장 길이를 초과했습니다.")
+    ;
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/repository/MySentenceRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/repository/MySentenceRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MySentenceRepository extends JpaRepository<MySentence, Long> {
+    // 저장된 문장 목록 조회
     List<MySentence> findAllByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long memberId);
     Optional<MySentence> findByIdAndMemberIdAndDeletedAtIsNull(Long sentenceId, Long memberId);
     boolean existsByIdAndMemberIdAndDeletedAtIsNull(Long sentenceId, Long memberId);

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/repository/MySentenceRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/repository/MySentenceRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 public interface MySentenceRepository extends JpaRepository<MySentence, Long> {
     // 저장된 문장 목록 조회
     List<MySentence> findAllByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long memberId);
-    Optional<MySentence> findByIdAndMemberIdAndDeletedAtIsNull(Long sentenceId, Long memberId);
+    // 나만의 문장 삭제
+    Optional<MySentence> findByIdAndDeletedAtIsNull(Long sentenceId);
     boolean existsByIdAndMemberIdAndDeletedAtIsNull(Long sentenceId, Long memberId);
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/repository/MySentenceRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/repository/MySentenceRepository.java
@@ -1,0 +1,13 @@
+package com.kwcapstone.server.domain.mysentence.repository;
+
+import com.kwcapstone.server.domain.mysentence.entity.MySentence;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MySentenceRepository extends JpaRepository<MySentence, Long> {
+    List<MySentence> findAllByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long memberId);
+    Optional<MySentence> findByIdAndMemberIdAndDeletedAtIsNull(Long sentenceId, Long memberId);
+    boolean existsByIdAndMemberIdAndDeletedAtIsNull(Long sentenceId, Long memberId);
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceCommandService.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceCommandService.java
@@ -1,0 +1,8 @@
+package com.kwcapstone.server.domain.mysentence.service;
+
+import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceCreateReqDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceCreateResDTO;
+
+public interface MySentenceCommandService {
+    MySentenceCreateResDTO createMySentence(MySentenceCreateReqDTO request);
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceCommandService.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceCommandService.java
@@ -2,7 +2,9 @@ package com.kwcapstone.server.domain.mysentence.service;
 
 import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceCreateReqDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceCreateResDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceDeleteResDTO;
 
 public interface MySentenceCommandService {
-    MySentenceCreateResDTO createMySentence(MySentenceCreateReqDTO request);
+    MySentenceCreateResDTO createMySentence(MySentenceCreateReqDTO request);  // 나만의 문장 생성
+    MySentenceDeleteResDTO deleteMySentence(Long sentenceId);  // 나만의 문장 삭제
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceCommandServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceCommandServiceImpl.java
@@ -1,0 +1,52 @@
+package com.kwcapstone.server.domain.mysentence.service;
+
+import com.kwcapstone.server.domain.member.entity.Member;
+import com.kwcapstone.server.domain.member.repository.MemberRepository;
+import com.kwcapstone.server.domain.mysentence.converter.MySentenceConverter;
+import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceCreateReqDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceCreateResDTO;
+import com.kwcapstone.server.domain.mysentence.entity.MySentence;
+import com.kwcapstone.server.domain.mysentence.exception.code.MySentenceErrorCode;
+import com.kwcapstone.server.domain.mysentence.repository.MySentenceRepository;
+import com.kwcapstone.server.global.apiPayload.exception.CustomException;
+import com.kwcapstone.server.global.apiPayload.response.ErrorCode;
+import com.kwcapstone.server.global.security.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MySentenceCommandServiceImpl implements MySentenceCommandService {
+
+    private static final int MAX_SENTENCE_LENGTH = 300;
+
+    private final MySentenceRepository mySentenceRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public MySentenceCreateResDTO createMySentence(MySentenceCreateReqDTO request) {
+        validateSentenceContent(request.getSentenceContent());
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
+
+        MySentence mySentence = MySentenceConverter.toMySentence(request, member);
+        MySentence savedMySentence = mySentenceRepository.save(mySentence);
+
+        return MySentenceConverter.toCreateResponse(savedMySentence);
+    }
+
+    private void validateSentenceContent(String sentenceContent) {
+        if (sentenceContent == null || sentenceContent.trim().isEmpty()) {
+            throw new CustomException(MySentenceErrorCode.EMPTY_SENTENCE_CONTENT);
+        }
+
+        if (sentenceContent.length() > MAX_SENTENCE_LENGTH) {
+            throw new CustomException(MySentenceErrorCode.SENTENCE_LENGTH_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceCommandServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceCommandServiceImpl.java
@@ -5,6 +5,7 @@ import com.kwcapstone.server.domain.member.repository.MemberRepository;
 import com.kwcapstone.server.domain.mysentence.converter.MySentenceConverter;
 import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceCreateReqDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceCreateResDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceDeleteResDTO;
 import com.kwcapstone.server.domain.mysentence.entity.MySentence;
 import com.kwcapstone.server.domain.mysentence.exception.code.MySentenceErrorCode;
 import com.kwcapstone.server.domain.mysentence.repository.MySentenceRepository;
@@ -38,6 +39,22 @@ public class MySentenceCommandServiceImpl implements MySentenceCommandService {
         MySentence savedMySentence = mySentenceRepository.save(mySentence);
 
         return MySentenceConverter.toCreateResponse(savedMySentence);
+    }
+
+    @Override
+    public MySentenceDeleteResDTO deleteMySentence(Long sentenceId) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        MySentence mySentence = mySentenceRepository.findByIdAndDeletedAtIsNull(sentenceId)
+                .orElseThrow(() -> new CustomException(MySentenceErrorCode.MY_SENTENCE_NOT_FOUND));
+
+        if(!mySentence.getMember().getId().equals(memberId)) {
+            throw new CustomException(MySentenceErrorCode.MY_SENTENCE_FORBIDDEN);
+        }
+
+        mySentence.softDelete();
+
+        return new MySentenceDeleteResDTO(mySentence.getId());
     }
 
     private void validateSentenceContent(String sentenceContent) {

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceQueryService.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceQueryService.java
@@ -1,0 +1,8 @@
+package com.kwcapstone.server.domain.mysentence.service;
+
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceListResDTO;
+
+public interface MySentenceQueryService {
+    // 저장된 문장 목록 조회
+    MySentenceListResDTO getMySentences();
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceQueryService.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceQueryService.java
@@ -1,8 +1,11 @@
 package com.kwcapstone.server.domain.mysentence.service;
 
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceDetailResDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceListResDTO;
 
 public interface MySentenceQueryService {
     // 저장된 문장 목록 조회
     MySentenceListResDTO getMySentences();
+    // 선택된 문장 상세 조회
+    MySentenceDetailResDTO getMySentenceDetail(Long sentenceId);
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceQueryServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceQueryServiceImpl.java
@@ -1,9 +1,12 @@
 package com.kwcapstone.server.domain.mysentence.service;
 
 import com.kwcapstone.server.domain.mysentence.converter.MySentenceConverter;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceDetailResDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceListResDTO;
 import com.kwcapstone.server.domain.mysentence.entity.MySentence;
+import com.kwcapstone.server.domain.mysentence.exception.code.MySentenceErrorCode;
 import com.kwcapstone.server.domain.mysentence.repository.MySentenceRepository;
+import com.kwcapstone.server.global.apiPayload.exception.CustomException;
 import com.kwcapstone.server.global.security.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,5 +28,19 @@ public class MySentenceQueryServiceImpl implements MySentenceQueryService {
         List<MySentence> mySentences = mySentenceRepository.findAllByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(memberId);
 
         return MySentenceConverter.toListResponse(mySentences);
+    }
+
+    @Override
+    public MySentenceDetailResDTO getMySentenceDetail(Long sentenceId) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        MySentence mySentence = mySentenceRepository.findByIdAndDeletedAtIsNull(sentenceId)
+                .orElseThrow(() -> new CustomException(MySentenceErrorCode.MY_SENTENCE_NOT_FOUND));
+
+        if (!mySentence.getMember().getId().equals(memberId)) {
+            throw new CustomException(MySentenceErrorCode.MY_SENTENCE_FORBIDDEN);
+        }
+
+        return MySentenceConverter.toDetailResponse(mySentence);
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceQueryServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceQueryServiceImpl.java
@@ -1,0 +1,29 @@
+package com.kwcapstone.server.domain.mysentence.service;
+
+import com.kwcapstone.server.domain.mysentence.converter.MySentenceConverter;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceListResDTO;
+import com.kwcapstone.server.domain.mysentence.entity.MySentence;
+import com.kwcapstone.server.domain.mysentence.repository.MySentenceRepository;
+import com.kwcapstone.server.global.security.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MySentenceQueryServiceImpl implements MySentenceQueryService {
+
+    private final MySentenceRepository mySentenceRepository;
+
+    @Override
+    public MySentenceListResDTO getMySentences() {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        List<MySentence> mySentences = mySentenceRepository.findAllByMemberIdAndDeletedAtIsNullOrderByCreatedAtDesc(memberId);
+
+        return MySentenceConverter.toListResponse(mySentences);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #10 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

### 구현 내용
- 나만의 문장 생성 API 구현
- 나만의 문장 목록 조회 API 구현
- 나만의 문장 단건 조회 API 구현
- 나만의 문장 삭제 API 구현 (Soft Delete)

### 세부 사항
- AccessToken 기반 로그인 사용자 식별
- 본인 소유 문장 검증 로직 추가
- 삭제된 문장 조회 제외 처리
- 공백 입력 검증 처리
- Swagger API 명세 작성
- 공통 응답 형식 적용

### API 목록
| Method | URL | 설명 |
|---|---|---|
| POST | `/warmups/my-sentences` | 나만의 문장 생성 |
| GET | `/warmups/my-sentences` | 저장된 문장 목록 조회 |
| GET | `/warmups/my-sentences/{sentenceId}` | 선택한 문장 상세 조회 |
| DELETE | `/warmups/my-sentences/{sentenceId}` | 나만의 문장 삭제 |

## 🧪 테스트 결과
> Apidog 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

노션에 있어여

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

- 삭제 API는 soft delete 방식으로 구현
- 삭제된 문장은 모든 조회 API에서 제외되도록 처리
- 예외 처리는 `CustomException` 및 `MySentenceErrorCode`를 사용