### PR TITLE
[Feat] 기초 발성 연습 API 구현

### DIFF
--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/client/BasicPronunciationAiClient.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/client/BasicPronunciationAiClient.java
@@ -1,0 +1,9 @@
+package com.kwcapstone.server.domain.basicpronunciation.client;
+
+import com.kwcapstone.server.domain.basicpronunciation.client.dto.request.VowelPracticeAiReqDTO;
+import com.kwcapstone.server.domain.basicpronunciation.client.dto.response.VowelPracticeAiResDTO;
+
+public interface BasicPronunciationAiClient {
+    VowelPracticeAiResDTO analyzeVowel(VowelPracticeAiReqDTO request);
+    byte[] synthesizeSpeech(String text);
+}

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/client/HttpBasicPronunciationAiClient.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/client/HttpBasicPronunciationAiClient.java
@@ -1,0 +1,87 @@
+package com.kwcapstone.server.domain.basicpronunciation.client;
+
+import com.kwcapstone.server.domain.basicpronunciation.client.dto.request.TtsAiReqDTO;
+import com.kwcapstone.server.domain.basicpronunciation.client.dto.request.VowelPracticeAiReqDTO;
+import com.kwcapstone.server.domain.basicpronunciation.client.dto.response.VowelPracticeAiResDTO;
+import com.kwcapstone.server.domain.basicpronunciation.exception.code.BasicPronunciationErrorCode;
+import com.kwcapstone.server.global.apiPayload.exception.CustomException;
+import com.kwcapstone.server.global.apiPayload.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HttpBasicPronunciationAiClient implements BasicPronunciationAiClient {
+    private static final String TTS_VOICE = "nova";
+    private static final double TTS_SPEED = 1.0;
+
+    private final RestClient aiRestClient;
+
+    @Override
+    public VowelPracticeAiResDTO analyzeVowel(VowelPracticeAiReqDTO request) {
+        try {
+            VowelPracticeAiResDTO response = aiRestClient.post()
+                    .uri("/practice/vowel")
+                    .body(request)
+                    .retrieve()
+                    .body(VowelPracticeAiResDTO.class);
+
+            if (response == null) {
+                log.error("AI server returned null response. uri=/practice/vowel");
+
+                throw new CustomException(ErrorCode.AI_SERVER_ERROR);
+            }
+
+            if (Boolean.FALSE.equals(response.getSuccess())) {
+                log.error(
+                        "AI server returned failure response. uri=/practice/vowel, success={}",
+                        response.getSuccess()
+                );
+
+                throw new CustomException(ErrorCode.AI_SERVER_ERROR);
+            }
+
+            return response;
+        } catch (RestClientException e) {
+            log.error(
+                    "Failed to call AI server. uri=/practice/vowel, message={}",
+                    e.getMessage(),
+                    e
+            );
+
+            throw new CustomException(ErrorCode.AI_SERVER_ERROR);
+        }
+    }
+
+    @Override
+    public byte[] synthesizeSpeech(String text) {
+        try {
+            byte[] response = aiRestClient.post()
+                    .uri("/tts")
+                    .body(new TtsAiReqDTO(text, TTS_VOICE, TTS_SPEED))
+                    .retrieve()
+                    .body(byte[].class);
+
+            if (response == null || response.length == 0) {
+                log.error("AI server returned empty TTS audio. uri=/tts, text={}", text);
+
+                throw new CustomException(BasicPronunciationErrorCode.EMPTY_TTS_AUDIO);
+            }
+
+            return response;
+        } catch (RestClientException e) {
+            log.error(
+                    "Failed to call AI server. uri=/tts, text={}, message={}",
+                    text,
+                    e.getMessage(),
+                    e
+            );
+
+            throw new CustomException(ErrorCode.AI_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/client/dto/request/TtsAiReqDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/client/dto/request/TtsAiReqDTO.java
@@ -1,0 +1,12 @@
+package com.kwcapstone.server.domain.basicpronunciation.client.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TtsAiReqDTO {
+    private String text;
+    private String voice;
+    private Double speed;
+}

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/client/dto/request/VowelPracticeAiReqDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/client/dto/request/VowelPracticeAiReqDTO.java
@@ -1,0 +1,11 @@
+package com.kwcapstone.server.domain.basicpronunciation.client.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class VowelPracticeAiReqDTO {
+    private String s3Url;
+    private String targetVowel;
+}

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/client/dto/response/VowelPracticeAiResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/client/dto/response/VowelPracticeAiResDTO.java
@@ -1,0 +1,19 @@
+package com.kwcapstone.server.domain.basicpronunciation.client.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VowelPracticeAiResDTO {
+    private Boolean success;
+    private String targetVowel;
+    private BigDecimal pronunciationScore;
+    private String pronunciationGrade;
+    private String pronunciationLabel;
+    private String feedback;
+}

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/controller/BasicPronunciationController.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/controller/BasicPronunciationController.java
@@ -1,0 +1,30 @@
+package com.kwcapstone.server.domain.basicpronunciation.controller;
+
+import com.kwcapstone.server.domain.basicpronunciation.dto.request.BasicPronunciationPracticeReqDTO;
+import com.kwcapstone.server.domain.basicpronunciation.dto.response.BasicPronunciationPracticeResDTO;
+import com.kwcapstone.server.domain.basicpronunciation.service.BasicPronunciationService;
+import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
+import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/warmups/basic-pronunciation/practices")
+public class BasicPronunciationController {
+    private final BasicPronunciationService basicPronunciationService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<BasicPronunciationPracticeResDTO> analyzePractice(
+            @ModelAttribute @Valid BasicPronunciationPracticeReqDTO request
+    ) {
+        BasicPronunciationPracticeResDTO result = basicPronunciationService.analyzePractice(request);
+
+        return ApiResponse.onSuccess(result, SuccessCode.CREATED, request.getClientRequestId());
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/controller/BasicPronunciationController.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/controller/BasicPronunciationController.java
@@ -1,17 +1,16 @@
 package com.kwcapstone.server.domain.basicpronunciation.controller;
 
 import com.kwcapstone.server.domain.basicpronunciation.dto.request.BasicPronunciationPracticeReqDTO;
+import com.kwcapstone.server.domain.basicpronunciation.dto.response.BasicPronunciationLatestResDTO;
 import com.kwcapstone.server.domain.basicpronunciation.dto.response.BasicPronunciationPracticeResDTO;
+import com.kwcapstone.server.domain.basicpronunciation.enums.BasicVowel;
 import com.kwcapstone.server.domain.basicpronunciation.service.BasicPronunciationService;
 import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
 import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,5 +25,14 @@ public class BasicPronunciationController {
         BasicPronunciationPracticeResDTO result = basicPronunciationService.analyzePractice(request);
 
         return ApiResponse.onSuccess(result, SuccessCode.CREATED, request.getClientRequestId());
+    }
+
+    @GetMapping("/latest")
+    public ApiResponse<BasicPronunciationLatestResDTO> getLatestPractice(
+            @RequestParam BasicVowel targetVowel
+    ) {
+        BasicPronunciationLatestResDTO result = basicPronunciationService.getLatestPractice(targetVowel);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/converter/BasicPronunciationConverter.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/converter/BasicPronunciationConverter.java
@@ -1,5 +1,6 @@
 package com.kwcapstone.server.domain.basicpronunciation.converter;
 
+import com.kwcapstone.server.domain.basicpronunciation.dto.response.BasicPronunciationLatestResDTO;
 import com.kwcapstone.server.domain.basicpronunciation.dto.response.BasicPronunciationPracticeResDTO;
 import com.kwcapstone.server.domain.basicpronunciation.entity.BasicPronunciationPractice;
 import com.kwcapstone.server.domain.basicpronunciation.enums.BasicVowel;
@@ -40,6 +41,34 @@ public class BasicPronunciationConverter {
                 practice.getFeedback(),
                 voiceUrl,
                 modelVoiceUrl
+        );
+    }
+
+    public static BasicPronunciationLatestResDTO toLatestEmptyResponse() {
+        return new BasicPronunciationLatestResDTO(
+                false,
+                null
+        );
+    }
+
+    public static BasicPronunciationLatestResDTO toLatestResponse(
+            BasicPronunciationPractice practice,
+            String voiceUrl,
+            String modelVoiceUrl
+    ) {
+        BasicPronunciationLatestResDTO.Practice latestPractice =
+                new BasicPronunciationLatestResDTO.Practice(
+                        practice.getId(),
+                        practice.getAccuracyScore(),
+                        practice.getFeedback(),
+                        voiceUrl,
+                        modelVoiceUrl,
+                        practice.getCreatedAt()
+                );
+
+        return new BasicPronunciationLatestResDTO(
+                true,
+                latestPractice
         );
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/converter/BasicPronunciationConverter.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/converter/BasicPronunciationConverter.java
@@ -1,0 +1,45 @@
+package com.kwcapstone.server.domain.basicpronunciation.converter;
+
+import com.kwcapstone.server.domain.basicpronunciation.dto.response.BasicPronunciationPracticeResDTO;
+import com.kwcapstone.server.domain.basicpronunciation.entity.BasicPronunciationPractice;
+import com.kwcapstone.server.domain.basicpronunciation.enums.BasicVowel;
+import com.kwcapstone.server.domain.member.entity.Member;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class BasicPronunciationConverter {
+    public static BasicPronunciationPractice toPractice(
+            Member member,
+            String clientRequestId,
+            BasicVowel targetVowel,
+            String memberAudioKey,
+            BigDecimal accuracyScore,
+            String feedback
+    ) {
+        return BasicPronunciationPractice.builder()
+                .member(member)
+                .clientRequestId(clientRequestId)
+                .targetVowel(targetVowel)
+                .memberAudioKey(memberAudioKey)
+                .accuracyScore(accuracyScore)
+                .feedback(feedback)
+                .build();
+    }
+
+    public static BasicPronunciationPracticeResDTO toPracticeResponse(
+            BasicPronunciationPractice practice,
+            String voiceUrl,
+            String modelVoiceUrl
+    ) {
+        return new BasicPronunciationPracticeResDTO(
+                practice.getId(),
+                practice.getAccuracyScore(),
+                practice.getFeedback(),
+                voiceUrl,
+                modelVoiceUrl
+        );
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/dto/request/BasicPronunciationPracticeReqDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/dto/request/BasicPronunciationPracticeReqDTO.java
@@ -1,0 +1,21 @@
+package com.kwcapstone.server.domain.basicpronunciation.dto.request;
+
+import com.kwcapstone.server.domain.basicpronunciation.enums.BasicVowel;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+public class BasicPronunciationPracticeReqDTO {
+    @NotBlank
+    private String clientRequestId;
+
+    @NotNull
+    private BasicVowel targetVowel;
+
+    @NotNull
+    private MultipartFile voiceFile;
+}

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/dto/response/BasicPronunciationLatestResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/dto/response/BasicPronunciationLatestResDTO.java
@@ -1,0 +1,25 @@
+package com.kwcapstone.server.domain.basicpronunciation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class BasicPronunciationLatestResDTO {
+    private Boolean hasPractice;
+    private Practice practice;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Practice {
+        private Long practiceId;
+        private BigDecimal accuracyScore;
+        private String feedback;
+        private String voiceUrl;
+        private String modelVoiceUrl;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/dto/response/BasicPronunciationPracticeResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/dto/response/BasicPronunciationPracticeResDTO.java
@@ -1,0 +1,16 @@
+package com.kwcapstone.server.domain.basicpronunciation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class BasicPronunciationPracticeResDTO {
+    private Long practiceId;
+    private BigDecimal accuracyScore;
+    private String feedback;
+    private String voiceUrl;
+    private String modelVoiceUrl;
+}

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/entity/BasicPronunciationPractice.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/entity/BasicPronunciationPractice.java
@@ -1,0 +1,37 @@
+package com.kwcapstone.server.domain.basicpronunciation.entity;
+
+import com.kwcapstone.server.domain.basicpronunciation.enums.BasicVowel;
+import com.kwcapstone.server.domain.member.entity.Member;
+import com.kwcapstone.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "basic_pronunciation_practice", uniqueConstraints = {@UniqueConstraint(columnNames = {"member_id", "client_request_id"})})
+public class BasicPronunciationPractice extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "client_request_id", nullable = false)
+    private String clientRequestId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_vowel", nullable = false, length = 10)
+    private BasicVowel targetVowel;
+
+    @Column(name = "member_audio_key", nullable = false, length = 500)
+    private String memberAudioKey;
+
+    @Column(name = "accuracy_score", nullable = false, precision = 5, scale = 2)
+    private BigDecimal accuracyScore;
+
+    @Column(name = "feedback", nullable = false, columnDefinition = "TEXT")
+    private String feedback;
+}

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/enums/BasicVowel.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/enums/BasicVowel.java
@@ -1,0 +1,16 @@
+package com.kwcapstone.server.domain.basicpronunciation.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BasicVowel {
+    A("아"),
+    E("에"),
+    I("이"),
+    O("오"),
+    U("우");
+
+    private final String korean;
+}

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/exception/code/BasicPronunciationErrorCode.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/exception/code/BasicPronunciationErrorCode.java
@@ -1,0 +1,22 @@
+package com.kwcapstone.server.domain.basicpronunciation.exception.code;
+
+import com.kwcapstone.server.global.apiPayload.response.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum BasicPronunciationErrorCode implements BaseCode {
+    // BASIC_PRONUNCIATION 4XX (클라이언트 오류)
+    INVALID_TARGET_VOWEL(HttpStatus.BAD_REQUEST, "BASIC_PRONUNCIATION400", "지원하지 않는 목표 단모음입니다."),
+
+    // BASIC_PRONUNCIATION 5XX (서버 오류)
+    EMPTY_FEEDBACK(HttpStatus.INTERNAL_SERVER_ERROR, "BASIC_PRONUNCIATION500_1", "AI 서버가 피드백을 반환하지 않았습니다."),
+    EMPTY_TTS_AUDIO(HttpStatus.INTERNAL_SERVER_ERROR, "BASIC_PRONUNCIATION500_2", "AI 서버가 모범 발음 음성을 반환하지 않았습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/repository/BasicPronunciationPracticeRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/repository/BasicPronunciationPracticeRepository.java
@@ -1,0 +1,10 @@
+package com.kwcapstone.server.domain.basicpronunciation.repository;
+
+import com.kwcapstone.server.domain.basicpronunciation.entity.BasicPronunciationPractice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BasicPronunciationPracticeRepository extends JpaRepository<BasicPronunciationPractice, Long> {
+    Optional<BasicPronunciationPractice> findByMemberIdAndClientRequestId(Long memberId, String clientRequestId);
+}

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/repository/BasicPronunciationPracticeRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/repository/BasicPronunciationPracticeRepository.java
@@ -1,10 +1,12 @@
 package com.kwcapstone.server.domain.basicpronunciation.repository;
 
 import com.kwcapstone.server.domain.basicpronunciation.entity.BasicPronunciationPractice;
+import com.kwcapstone.server.domain.basicpronunciation.enums.BasicVowel;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface BasicPronunciationPracticeRepository extends JpaRepository<BasicPronunciationPractice, Long> {
     Optional<BasicPronunciationPractice> findByMemberIdAndClientRequestId(Long memberId, String clientRequestId);
+    Optional<BasicPronunciationPractice> findTopByMemberIdAndTargetVowelOrderByCreatedAtDesc(Long memberId, BasicVowel targetVowel);
 }

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/service/BasicPronunciationService.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/service/BasicPronunciationService.java
@@ -1,0 +1,8 @@
+package com.kwcapstone.server.domain.basicpronunciation.service;
+
+import com.kwcapstone.server.domain.basicpronunciation.dto.request.BasicPronunciationPracticeReqDTO;
+import com.kwcapstone.server.domain.basicpronunciation.dto.response.BasicPronunciationPracticeResDTO;
+
+public interface BasicPronunciationService {
+    BasicPronunciationPracticeResDTO analyzePractice(BasicPronunciationPracticeReqDTO request);
+}

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/service/BasicPronunciationService.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/service/BasicPronunciationService.java
@@ -1,8 +1,11 @@
 package com.kwcapstone.server.domain.basicpronunciation.service;
 
 import com.kwcapstone.server.domain.basicpronunciation.dto.request.BasicPronunciationPracticeReqDTO;
+import com.kwcapstone.server.domain.basicpronunciation.dto.response.BasicPronunciationLatestResDTO;
 import com.kwcapstone.server.domain.basicpronunciation.dto.response.BasicPronunciationPracticeResDTO;
+import com.kwcapstone.server.domain.basicpronunciation.enums.BasicVowel;
 
 public interface BasicPronunciationService {
     BasicPronunciationPracticeResDTO analyzePractice(BasicPronunciationPracticeReqDTO request);
+    BasicPronunciationLatestResDTO getLatestPractice(BasicVowel targetVowel);
 }

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/service/BasicPronunciationServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/service/BasicPronunciationServiceImpl.java
@@ -5,6 +5,7 @@ import com.kwcapstone.server.domain.basicpronunciation.client.dto.request.VowelP
 import com.kwcapstone.server.domain.basicpronunciation.client.dto.response.VowelPracticeAiResDTO;
 import com.kwcapstone.server.domain.basicpronunciation.converter.BasicPronunciationConverter;
 import com.kwcapstone.server.domain.basicpronunciation.dto.request.BasicPronunciationPracticeReqDTO;
+import com.kwcapstone.server.domain.basicpronunciation.dto.response.BasicPronunciationLatestResDTO;
 import com.kwcapstone.server.domain.basicpronunciation.dto.response.BasicPronunciationPracticeResDTO;
 import com.kwcapstone.server.domain.basicpronunciation.entity.BasicPronunciationPractice;
 import com.kwcapstone.server.domain.basicpronunciation.enums.BasicVowel;
@@ -92,12 +93,33 @@ public class BasicPronunciationServiceImpl implements BasicPronunciationService 
         }
     }
 
+    @Override
+    public BasicPronunciationLatestResDTO getLatestPractice(BasicVowel targetVowel) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        return basicPronunciationPracticeRepository
+                .findTopByMemberIdAndTargetVowelOrderByCreatedAtDesc(memberId, targetVowel)
+                .map(this::toLatestResponseWithUrls)
+                .orElseGet(BasicPronunciationConverter::toLatestEmptyResponse);
+    }
+
     // 응답 생성 메서드
     private BasicPronunciationPracticeResDTO toPracticeResponseWithUrls(BasicPronunciationPractice practice) {
         String voiceUrl = audioStorageService.generatePresignedGetUrl(practice.getMemberAudioKey());
         String modelVoiceUrl = generateModelVoiceUrl(practice.getTargetVowel());
 
         return BasicPronunciationConverter.toPracticeResponse(
+                practice,
+                voiceUrl,
+                modelVoiceUrl
+        );
+    }
+
+    private BasicPronunciationLatestResDTO toLatestResponseWithUrls(BasicPronunciationPractice practice) {
+        String voiceUrl = audioStorageService.generatePresignedGetUrl(practice.getMemberAudioKey());
+        String modelVoiceUrl = generateModelVoiceUrl(practice.getTargetVowel());
+
+        return BasicPronunciationConverter.toLatestResponse(
                 practice,
                 voiceUrl,
                 modelVoiceUrl

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/service/BasicPronunciationServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/service/BasicPronunciationServiceImpl.java
@@ -1,0 +1,144 @@
+package com.kwcapstone.server.domain.basicpronunciation.service;
+
+import com.kwcapstone.server.domain.basicpronunciation.client.BasicPronunciationAiClient;
+import com.kwcapstone.server.domain.basicpronunciation.client.dto.request.VowelPracticeAiReqDTO;
+import com.kwcapstone.server.domain.basicpronunciation.client.dto.response.VowelPracticeAiResDTO;
+import com.kwcapstone.server.domain.basicpronunciation.converter.BasicPronunciationConverter;
+import com.kwcapstone.server.domain.basicpronunciation.dto.request.BasicPronunciationPracticeReqDTO;
+import com.kwcapstone.server.domain.basicpronunciation.dto.response.BasicPronunciationPracticeResDTO;
+import com.kwcapstone.server.domain.basicpronunciation.entity.BasicPronunciationPractice;
+import com.kwcapstone.server.domain.basicpronunciation.enums.BasicVowel;
+import com.kwcapstone.server.domain.basicpronunciation.exception.code.BasicPronunciationErrorCode;
+import com.kwcapstone.server.domain.basicpronunciation.repository.BasicPronunciationPracticeRepository;
+import com.kwcapstone.server.domain.member.entity.Member;
+import com.kwcapstone.server.domain.member.exception.code.MemberErrorCode;
+import com.kwcapstone.server.domain.member.repository.MemberRepository;
+import com.kwcapstone.server.global.apiPayload.exception.CustomException;
+import com.kwcapstone.server.global.apiPayload.response.ErrorCode;
+import com.kwcapstone.server.global.security.SecurityUtil;
+import com.kwcapstone.server.global.storage.audio.AudioStorageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.math.BigDecimal;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BasicPronunciationServiceImpl implements BasicPronunciationService {
+    private static final String MEMBER_AUDIO_PREFIX = "warmups/basic-pronunciation/member";
+    private static final String MODEL_AUDIO_PREFIX = "warmups/basic-pronunciation/model";
+    private static final String MODEL_AUDIO_EXTENSION = ".mp3";
+    private static final String MODEL_AUDIO_CONTENT_TYPE = "audio/mpeg";
+
+    private final BasicPronunciationPracticeRepository basicPronunciationPracticeRepository;
+    private final MemberRepository memberRepository;
+    private final AudioStorageService audioStorageService;
+    private final BasicPronunciationAiClient basicPronunciationAiClient;
+
+    @Override
+    public BasicPronunciationPracticeResDTO analyzePractice(BasicPronunciationPracticeReqDTO request) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        // 중복 요청 확인
+        BasicPronunciationPractice duplicated = basicPronunciationPracticeRepository
+                .findByMemberIdAndClientRequestId(memberId, request.getClientRequestId())
+                .orElse(null);
+
+        if (duplicated != null) {
+            return toPracticeResponseWithUrls(duplicated);
+        }
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 사용자 녹음 파일 S3 업로드
+        String memberAudioKey = audioStorageService.upload(
+                buildMemberAudioKeyPrefix(memberId),
+                request.getClientRequestId(),
+                request.getVoiceFile()
+        );
+
+        try {
+            String memberVoiceUrlForAi = audioStorageService.generatePresignedGetUrl(memberAudioKey);
+
+            VowelPracticeAiResDTO aiResult = basicPronunciationAiClient.analyzeVowel(
+                    new VowelPracticeAiReqDTO(memberVoiceUrlForAi, request.getTargetVowel().getKorean())
+            );
+
+            BigDecimal accuracyScore = resolveAccuracyScore(aiResult);
+            String feedback = resolveFeedback(aiResult);
+
+            BasicPronunciationPractice practice = BasicPronunciationConverter.toPractice(
+                    member,
+                    request.getClientRequestId(),
+                    request.getTargetVowel(),
+                    memberAudioKey,
+                    accuracyScore,
+                    feedback
+            );
+
+            BasicPronunciationPractice savedPractice = basicPronunciationPracticeRepository.save(practice);
+
+            return toPracticeResponseWithUrls(savedPractice);
+        } catch (Exception e) {
+            audioStorageService.delete(memberAudioKey);
+
+            throw e;
+        }
+    }
+
+    // 응답 생성 메서드
+    private BasicPronunciationPracticeResDTO toPracticeResponseWithUrls(BasicPronunciationPractice practice) {
+        String voiceUrl = audioStorageService.generatePresignedGetUrl(practice.getMemberAudioKey());
+        String modelVoiceUrl = generateModelVoiceUrl(practice.getTargetVowel());
+
+        return BasicPronunciationConverter.toPracticeResponse(
+                practice,
+                voiceUrl,
+                modelVoiceUrl
+        );
+    }
+
+    // 모범 음성 URL 생성 메서드
+    private String generateModelVoiceUrl(BasicVowel targetVowel) {
+        String modelAudioKey = audioStorageService.buildKey(
+                MODEL_AUDIO_PREFIX,
+                targetVowel.name(),
+                MODEL_AUDIO_EXTENSION
+        );
+
+        // S3에 해당 모범 음성 파일이 없는 경우 AI 서버의 TTS를 통해 생성
+        if (!audioStorageService.exists(modelAudioKey)) {
+            byte[] audioBytes = basicPronunciationAiClient.synthesizeSpeech(targetVowel.getKorean());
+            audioStorageService.uploadBytes(modelAudioKey, audioBytes, MODEL_AUDIO_CONTENT_TYPE);
+        }
+
+        return audioStorageService.generatePresignedGetUrl(modelAudioKey);
+    }
+
+    // 사용자 음성 저장 경로 prefix 생성 메서드
+    private String buildMemberAudioKeyPrefix(Long memberId) {
+        return MEMBER_AUDIO_PREFIX + "/" + memberId;
+    }
+
+    private BigDecimal resolveAccuracyScore(VowelPracticeAiResDTO aiResult) {
+        if (aiResult != null && aiResult.getPronunciationScore() != null) {
+            return aiResult.getPronunciationScore();
+        }
+
+        throw new CustomException(ErrorCode.AI_SERVER_ERROR);
+    }
+
+    private String resolveFeedback(VowelPracticeAiResDTO aiResult) {
+        if (aiResult != null && StringUtils.hasText(aiResult.getFeedback())) {
+            return aiResult.getFeedback().trim();
+        }
+
+        throw new CustomException(BasicPronunciationErrorCode.EMPTY_FEEDBACK);
+    }
+}

--- a/src/main/java/com/kwcapstone/server/global/storage/audio/AudioStorageService.java
+++ b/src/main/java/com/kwcapstone/server/global/storage/audio/AudioStorageService.java
@@ -9,4 +9,7 @@ public interface AudioStorageService {
     void delete(String key);
     void deleteAll(Collection<String> keys);
     String generatePresignedGetUrl(String key);
+    String buildKey(String keyPrefix, String fileBaseName, String extension);
+    boolean exists(String key);
+    String uploadBytes(String key, byte[] bytes, String contentType);
 }

--- a/src/main/java/com/kwcapstone/server/global/storage/audio/S3AudioStorageService.java
+++ b/src/main/java/com/kwcapstone/server/global/storage/audio/S3AudioStorageService.java
@@ -10,10 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
@@ -175,7 +172,8 @@ public class S3AudioStorageService implements AudioStorageService {
     }
 
     // S3 key(=S3 파일 경로) 생성 메서드
-    private String buildKey(String keyPrefix, String fileBaseName, String extension) {
+    @Override
+    public String buildKey(String keyPrefix, String fileBaseName, String extension) {
         String normalizedRoot = trimSlashes(audioRootPath);
         String normalizedPrefix = trimSlashes(keyPrefix);
         String normalizedBaseName = sanitizeFileBaseName(fileBaseName);
@@ -185,6 +183,103 @@ public class S3AudioStorageService implements AudioStorageService {
         }
 
         return normalizedRoot + "/" + normalizedPrefix + "/" + normalizedBaseName + extension;
+    }
+
+    // 모범 음성 캐싱용 메서드
+    @Override
+    public boolean exists(String key) {
+        if (key == null || key.isBlank()) {
+            return false;
+        }
+
+        try {
+            HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+
+            s3Client.headObject(headObjectRequest);
+
+            return true;
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                return false;
+            }
+
+            log.error(
+                    "S3Exception during exists check. bucket={}, key={}, statusCode={}, errorCode={}, errorMessage={}",
+                    bucket,
+                    key,
+                    e.statusCode(),
+                    e.awsErrorDetails() != null ? e.awsErrorDetails().errorCode() : null,
+                    e.awsErrorDetails() != null ? e.awsErrorDetails().errorMessage() : e.getMessage(),
+                    e
+            );
+
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+        } catch (SdkClientException e) {
+            log.error(
+                    "SdkClientException during exists check. bucket={}, key={}, message={}",
+                    bucket,
+                    key,
+                    e.getMessage(),
+                    e
+            );
+
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    // 모범 음성 최초 업로드용 메서드
+    @Override
+    public String uploadBytes(String key, byte[] bytes, String contentType) {
+        if (key == null || key.isBlank() || bytes == null || bytes.length == 0) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        log.info(
+                "S3 bytes upload start. bucket={}, key={}, contentType={}, size={}",
+                bucket,
+                key,
+                contentType,
+                bytes.length
+        );
+
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType(contentType)
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromBytes(bytes));
+
+            log.info("S3 bytes upload success. bucket={}, key={}", bucket, key);
+
+            return key;
+        } catch (S3Exception e) {
+            log.error(
+                    "S3Exception during bytes upload. bucket={}, key={}, statusCode={}, errorCode={}, errorMessage={}",
+                    bucket,
+                    key,
+                    e.statusCode(),
+                    e.awsErrorDetails() != null ? e.awsErrorDetails().errorCode() : null,
+                    e.awsErrorDetails() != null ? e.awsErrorDetails().errorMessage() : e.getMessage(),
+                    e
+            );
+
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+        } catch (SdkClientException e) {
+            log.error(
+                    "SdkClientException during bytes upload. bucket={}, key={}, message={}",
+                    bucket,
+                    key,
+                    e.getMessage(),
+                    e
+            );
+
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
     }
 
     // 경로 문자열의 앞뒤 / 제거 메서드(경로 정규화)


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #13

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

기초 발성 연습 기능을 위한 API를 구현하였음

사용자가 단모음 `A, E, I, O, U` 중 하나를 선택해 녹음 파일을 업로드하면, Spring 서버에서 음성 파일을 S3에 저장하고 AI 서버의 `/practice/vowel` API를 호출하여 발음 정확도와 AI 피드백을 생성

### 구현한 API

- `POST /api/warmups/basic-pronunciation/practices`
- `GET /api/warmups/basic-pronunciation/practices/latest`

### 주요 구현 내용

- 목표 단모음 `A, E, I, O, U` Enum 처리
- 사용자 녹음 파일 S3 업로드
- S3 presigned URL을 AI 서버 `/practice/vowel`에 전달
- AI 서버 응답 기반 발음 정확도 및 피드백 저장
- `clientRequestId` 기반 중복 요청 방지 처리
- 내 녹음 재생용 `voiceUrl` 반환
- 모범 발음 재생용 `modelVoiceUrl` 반환
- 특정 단모음 기준 가장 최근 연습 결과 조회
- 최근 기록이 없는 경우 `hasPractice=false` 응답 처리


## 🧪 테스트 결과
> Apidog 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

POST /api/warmups/basic-pronunciation/practices

<img src="https://github.com/user-attachments/assets/c0287030-5bff-4a12-9672-33c4ecff6f8b" />

<br>

`아` 녹음 파일 입력 시

<img src="https://github.com/user-attachments/assets/18e9bfcf-1a65-4cb1-8295-d03239b89d6a" />

<br>

`안녕하세요` 녹음 파일 입력 시

<img src="https://github.com/user-attachments/assets/aab65b3f-c8f1-4f9e-9122-0068b54ecbe0" />

<br>

지정된 형식의 음성 파일 외의 파일 업로드 시

<img src="https://github.com/user-attachments/assets/ba8029b7-b059-498a-8515-c641f3541874" />

<br>

GET /api/warmups/basic-pronunciation/practices/latest

<img src="https://github.com/user-attachments/assets/44c2d839-7ea2-43a0-a86c-e394fb70f371" />

<br>

가장 최근 결과를 조회하여 반환함

<img src="https://github.com/user-attachments/assets/3e7bc2e6-e5d5-4223-bec6-68b370195a9b" />

로그인하지 않고 API 요청 시

<img src="https://github.com/user-attachments/assets/f9d2097b-ac23-4557-9b52-a24f7d5006c8" />

<img src="https://github.com/user-attachments/assets/99d3b66a-dd97-4dd5-b274-c0b970cd8dcf" />




## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

DB에는 재녹음 기록을 모두 저장하되, UX에서는 특정 단모음의 가장 최근 결과만 접근 가능하도록 처리
모범 발음은 AI 서버 TTS 결과를 표준 발음으로 간주하여 임시 제공 중
`voiceUrl`과 `modelVoiceUrl`은 DB에 저장하지 않고, S3 object key를 기반으로 요청 시점에 presigned URL을 생성하여 반환 - 캐싱 적용