### PR TITLE
[Feat] 나만의 문장 음성 파일 조회 API 구현

### DIFF
--- a/src/main/java/com/kwcapstone/server/domain/mysentence/client/HttpMySentenceAiClient.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/client/HttpMySentenceAiClient.java
@@ -1,0 +1,28 @@
+package com.kwcapstone.server.domain.mysentence.client;
+
+import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceTtsReqDTO;
+import com.kwcapstone.server.domain.mysentence.exception.code.MySentenceErrorCode;
+import com.kwcapstone.server.global.apiPayload.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+public class HttpMySentenceAiClient implements MySentenceAiClient {
+
+    private final RestClient aiRestClient;
+
+    @Override
+    public byte[] requestTts(MySentenceTtsReqDTO request) {
+        try {
+            return aiRestClient.post()
+                    .uri("/tts")
+                    .body(request)
+                    .retrieve()
+                    .body(byte[].class);
+        } catch (Exception e) {
+            throw new CustomException(MySentenceErrorCode.TTS_GENERATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/client/MySentenceAiClient.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/client/MySentenceAiClient.java
@@ -1,0 +1,7 @@
+package com.kwcapstone.server.domain.mysentence.client;
+
+import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceTtsReqDTO;
+
+public interface MySentenceAiClient {
+    byte[] requestTts(MySentenceTtsReqDTO request);
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/controller/MySentenceAudioController.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/controller/MySentenceAudioController.java
@@ -1,6 +1,7 @@
 package com.kwcapstone.server.domain.mysentence.controller;
 
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceTtsResDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceUserAudioResDTO;
 import com.kwcapstone.server.domain.mysentence.service.MySentenceAudioService;
 import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
 import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
@@ -24,6 +25,17 @@ public class MySentenceAudioController {
             @PathVariable Long sentenceId
     ) {
         MySentenceTtsResDTO result = mySentenceAudioService.getTts(sentenceId);
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    @Operation(summary = "내 음성 듣기")
+    @GetMapping("/{sentenceId}/user-audio")
+    public ApiResponse<MySentenceUserAudioResDTO> getUserAudio(
+            @PathVariable Long sentenceId
+    ) {
+        MySentenceUserAudioResDTO result =
+                mySentenceAudioService.getUserAudio(sentenceId);
+
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/controller/MySentenceAudioController.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/controller/MySentenceAudioController.java
@@ -1,0 +1,29 @@
+package com.kwcapstone.server.domain.mysentence.controller;
+
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceTtsResDTO;
+import com.kwcapstone.server.domain.mysentence.service.MySentenceAudioService;
+import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
+import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/warmups/my-sentences")
+public class MySentenceAudioController {
+
+    private final MySentenceAudioService mySentenceAudioService;
+
+    @Operation(summary = "AI TTS 음성 듣기")
+    @GetMapping("/{sentenceId}/tts")
+    public ApiResponse<MySentenceTtsResDTO> getTts(
+            @PathVariable Long sentenceId
+    ) {
+        MySentenceTtsResDTO result = mySentenceAudioService.getTts(sentenceId);
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/dto/request/MySentenceTtsReqDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/dto/request/MySentenceTtsReqDTO.java
@@ -1,0 +1,12 @@
+package com.kwcapstone.server.domain.mysentence.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MySentenceTtsReqDTO {
+    private String text;
+    private String voice;
+    private Double speed;
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/MySentenceTtsResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/MySentenceTtsResDTO.java
@@ -1,0 +1,13 @@
+package com.kwcapstone.server.domain.mysentence.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MySentenceTtsResDTO {
+    private Long sentenceId;
+    private String sentenceContent;
+    private String aiAudioUrl;
+    private Long expiresIn;
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/MySentenceUserAudioResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/MySentenceUserAudioResDTO.java
@@ -1,0 +1,13 @@
+package com.kwcapstone.server.domain.mysentence.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MySentenceUserAudioResDTO {
+    private Long sentenceId;
+    private Long analysisId;
+    private String userAudioUrl;
+    private Long expiresIn;
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/entity/MySentenceAnalysisResult.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/entity/MySentenceAnalysisResult.java
@@ -1,0 +1,52 @@
+package com.kwcapstone.server.domain.mysentence.entity;
+
+import com.kwcapstone.server.domain.member.entity.Member;
+import com.kwcapstone.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "my_sentence_analysis_result")
+public class MySentenceAnalysisResult extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "my_sentence_id", nullable = false)
+    private MySentence mySentence;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "user_audio_key", length = 500)
+    private String userAudioKey;
+
+    @Column(name = "pronunciation_score", nullable = false, precision = 5, scale = 2)
+    private BigDecimal pronunciationScore;
+
+    @Column(name = "speech_rate_score", nullable = false, precision = 4, scale = 2)
+    private BigDecimal speechRateScore;
+
+    @Column(name = "silence_ratio", nullable = false, precision = 5, scale = 2)
+    private BigDecimal silenceRatio;
+
+    @Column(name = "ai_feedback", columnDefinition = "TEXT")
+    private String aiFeedback;
+
+    @Column(name = "syllable_result_json", nullable = false, columnDefinition = "TEXT")
+    private String syllableResultJson;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/exception/code/MySentenceErrorCode.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/exception/code/MySentenceErrorCode.java
@@ -11,9 +11,10 @@ public enum MySentenceErrorCode implements BaseCode {
 
     EMPTY_SENTENCE_CONTENT(HttpStatus.BAD_REQUEST, "WARMUP_400_1", "문장 내용이 비어있습니다."),
     SENTENCE_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "WARMUP_400_2", "문장 길이를 초과했습니다."),
-    MY_SENTENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "WARMUP404", "존재하지 않거나 이미 삭제된 문장입니다."),
+    MY_SENTENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "WARMUP_404_1", "존재하지 않거나 이미 삭제된 문장입니다."),
     MY_SENTENCE_FORBIDDEN(HttpStatus.FORBIDDEN, "WARMUP403", "본인의 문장이 아니어서 삭제할 수 없습니다."),
-    TTS_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WARMUP500_1", "TTS 생성에 실패했습니다.")
+    TTS_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WARMUP500_1", "TTS 생성에 실패했습니다."),
+    RECENT_USER_AUDIO_NOT_FOUND(HttpStatus.NOT_FOUND, "WARMUP_404_2", "최근 녹음 음성이 없습니다.")
     ;
 
 

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/exception/code/MySentenceErrorCode.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/exception/code/MySentenceErrorCode.java
@@ -12,7 +12,8 @@ public enum MySentenceErrorCode implements BaseCode {
     EMPTY_SENTENCE_CONTENT(HttpStatus.BAD_REQUEST, "WARMUP_400_1", "문장 내용이 비어있습니다."),
     SENTENCE_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "WARMUP_400_2", "문장 길이를 초과했습니다."),
     MY_SENTENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "WARMUP404", "존재하지 않거나 이미 삭제된 문장입니다."),
-    MY_SENTENCE_FORBIDDEN(HttpStatus.FORBIDDEN, "WARMUP403", "본인의 문장이 아니어서 삭제할 수 없습니다.")
+    MY_SENTENCE_FORBIDDEN(HttpStatus.FORBIDDEN, "WARMUP403", "본인의 문장이 아니어서 삭제할 수 없습니다."),
+    TTS_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WARMUP500_1", "TTS 생성에 실패했습니다.")
     ;
 
 

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/exception/code/MySentenceErrorCode.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/exception/code/MySentenceErrorCode.java
@@ -17,7 +17,7 @@ public enum MySentenceErrorCode implements BaseCode {
     RECENT_USER_AUDIO_NOT_FOUND(HttpStatus.NOT_FOUND, "WARMUP_404_2", "최근 녹음 음성이 없습니다."),
 
     // 5xx
-    TTS_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WARMUP_500_1", "TTS 생성에 실패했습니다.")
+    TTS_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WARMUP_500", "TTS 생성에 실패했습니다.")
     ;
 
 

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/repository/MySentenceAnalysisResultRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/repository/MySentenceAnalysisResultRepository.java
@@ -1,0 +1,10 @@
+package com.kwcapstone.server.domain.mysentence.repository;
+
+import com.kwcapstone.server.domain.mysentence.entity.MySentenceAnalysisResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MySentenceAnalysisResultRepository extends JpaRepository<MySentenceAnalysisResult, Long> {
+    Optional<MySentenceAnalysisResult>findTopByMySentence_IdAndMember_IdOrderByCreatedAtDesc(Long mySentenceId, Long memberId);
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceAudioService.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceAudioService.java
@@ -1,7 +1,9 @@
 package com.kwcapstone.server.domain.mysentence.service;
 
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceTtsResDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceUserAudioResDTO;
 
 public interface MySentenceAudioService {
     MySentenceTtsResDTO getTts(Long sentenceId);  // TTS
+    MySentenceUserAudioResDTO getUserAudio(Long sentenceId);  // user audio
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceAudioService.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceAudioService.java
@@ -1,0 +1,7 @@
+package com.kwcapstone.server.domain.mysentence.service;
+
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceTtsResDTO;
+
+public interface MySentenceAudioService {
+    MySentenceTtsResDTO getTts(Long sentenceId);  // TTS
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceAudioServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceAudioServiceImpl.java
@@ -3,8 +3,11 @@ package com.kwcapstone.server.domain.mysentence.service;
 import com.kwcapstone.server.domain.mysentence.client.MySentenceAiClient;
 import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceTtsReqDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceTtsResDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceUserAudioResDTO;
 import com.kwcapstone.server.domain.mysentence.entity.MySentence;
+import com.kwcapstone.server.domain.mysentence.entity.MySentenceAnalysisResult;
 import com.kwcapstone.server.domain.mysentence.exception.code.MySentenceErrorCode;
+import com.kwcapstone.server.domain.mysentence.repository.MySentenceAnalysisResultRepository;
 import com.kwcapstone.server.domain.mysentence.repository.MySentenceRepository;
 import com.kwcapstone.server.global.apiPayload.exception.CustomException;
 import com.kwcapstone.server.global.security.SecurityUtil;
@@ -26,6 +29,7 @@ public class MySentenceAudioServiceImpl implements MySentenceAudioService {
     private final MySentenceRepository mySentenceRepository;
     private final MySentenceAiClient mySentenceAiClient;
     private final AudioStorageService audioStorageService;
+    private final MySentenceAnalysisResultRepository mySentenceAnalysisResultRepository;
 
     @Override
     public MySentenceTtsResDTO getTts(Long sentenceId) {
@@ -68,6 +72,39 @@ public class MySentenceAudioServiceImpl implements MySentenceAudioService {
                 mySentence.getSentenceContent(),
                 aiAudioUrl,
                 PRESIGNED_EXPIRES_IN
+        );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MySentenceUserAudioResDTO getUserAudio(Long sentenceId) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        MySentence mySentence = mySentenceRepository.findByIdAndDeletedAtIsNull(sentenceId)
+                .orElseThrow(() -> new CustomException(MySentenceErrorCode.MY_SENTENCE_NOT_FOUND));
+
+        if (!mySentence.getMember().getId().equals(memberId)) {
+            throw new CustomException(MySentenceErrorCode.MY_SENTENCE_FORBIDDEN);
+        }
+
+        MySentenceAnalysisResult latestResult =
+                mySentenceAnalysisResultRepository
+                        .findTopByMySentence_IdAndMember_IdOrderByCreatedAtDesc(sentenceId, memberId)
+                        .orElseThrow(() -> new CustomException(
+                                MySentenceErrorCode.RECENT_USER_AUDIO_NOT_FOUND
+                        ));
+
+        if (latestResult.getUserAudioKey() == null || latestResult.getUserAudioKey().isBlank()) {
+            throw new CustomException(MySentenceErrorCode.RECENT_USER_AUDIO_NOT_FOUND);
+        }
+
+        String userAudioUrl = audioStorageService.generatePresignedGetUrl(latestResult.getUserAudioKey());
+
+        return new MySentenceUserAudioResDTO(
+                mySentence.getId(),
+                latestResult.getId(),
+                userAudioUrl,
+                600L
         );
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceAudioServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceAudioServiceImpl.java
@@ -1,0 +1,73 @@
+package com.kwcapstone.server.domain.mysentence.service;
+
+import com.kwcapstone.server.domain.mysentence.client.MySentenceAiClient;
+import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceTtsReqDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceTtsResDTO;
+import com.kwcapstone.server.domain.mysentence.entity.MySentence;
+import com.kwcapstone.server.domain.mysentence.exception.code.MySentenceErrorCode;
+import com.kwcapstone.server.domain.mysentence.repository.MySentenceRepository;
+import com.kwcapstone.server.global.apiPayload.exception.CustomException;
+import com.kwcapstone.server.global.security.SecurityUtil;
+import com.kwcapstone.server.global.storage.audio.AudioStorageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MySentenceAudioServiceImpl implements MySentenceAudioService {
+
+    private static final String PREFIX_ROOT = "my-sentence";
+    private static final String TTS_VOICE = "nova";
+    private static final double TTS_SPEED = 1.0;
+    private static final long PRESIGNED_EXPIRES_IN = 600L;
+
+    private final MySentenceRepository mySentenceRepository;
+    private final MySentenceAiClient mySentenceAiClient;
+    private final AudioStorageService audioStorageService;
+
+    @Override
+    public MySentenceTtsResDTO getTts(Long sentenceId) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        MySentence mySentence = mySentenceRepository.findByIdAndDeletedAtIsNull(sentenceId)
+                .orElseThrow(() -> new CustomException(MySentenceErrorCode.MY_SENTENCE_NOT_FOUND));
+
+        if (!mySentence.getMember().getId().equals(memberId)) {
+            throw new CustomException(MySentenceErrorCode.MY_SENTENCE_FORBIDDEN);
+        }
+
+        if (mySentence.getAiAudioKey() == null || mySentence.getAiAudioKey().isBlank()) {
+            byte[] mp3Bytes = mySentenceAiClient.requestTts(
+                    new MySentenceTtsReqDTO(
+                            mySentence.getSentenceContent(),
+                            TTS_VOICE,
+                            TTS_SPEED
+                    )
+            );
+
+            String keyPrefix = PREFIX_ROOT + "/" + memberId;
+            String fileBaseName = "sentence-" + sentenceId + "-tts";
+
+            String aiAudioKey = audioStorageService.uploadBytes(
+                    keyPrefix,
+                    fileBaseName,
+                    mp3Bytes,
+                    "audio/mpeg",
+                    "mp3"
+            );
+
+            mySentence.updateAiAudioKey(aiAudioKey);
+        }
+
+        String aiAudioUrl = audioStorageService.generatePresignedGetUrl(mySentence.getAiAudioKey());
+
+        return new MySentenceTtsResDTO(
+                mySentence.getId(),
+                mySentence.getSentenceContent(),
+                aiAudioUrl,
+                PRESIGNED_EXPIRES_IN
+        );
+    }
+}

--- a/src/main/java/com/kwcapstone/server/global/storage/audio/AudioStorageService.java
+++ b/src/main/java/com/kwcapstone/server/global/storage/audio/AudioStorageService.java
@@ -9,4 +9,13 @@ public interface AudioStorageService {
     void delete(String key);
     void deleteAll(Collection<String> keys);
     String generatePresignedGetUrl(String key);
+
+    // TTS
+    String uploadBytes(
+            String keyPrefix,
+            String fileBaseName,
+            byte[] bytes,
+            String contentType,
+            String extension
+    );
 }

--- a/src/main/java/com/kwcapstone/server/global/storage/audio/S3AudioStorageService.java
+++ b/src/main/java/com/kwcapstone/server/global/storage/audio/S3AudioStorageService.java
@@ -174,6 +174,31 @@ public class S3AudioStorageService implements AudioStorageService {
         }
     }
 
+    @Override  // TTS
+    public String uploadBytes(
+            String keyPrefix,
+            String fileBaseName,
+            byte[] bytes,
+            String contentType,
+            String extension
+    ) {
+        String objectKey = buildKey(keyPrefix, fileBaseName, "."+extension);
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(objectKey)
+                .contentType(contentType)
+                .contentLength((long) bytes.length)
+                .build();
+
+        s3Client.putObject(
+                putObjectRequest,
+                RequestBody.fromBytes(bytes)
+        );
+
+        return objectKey;
+    }
+
     // S3 key(=S3 파일 경로) 생성 메서드
     private String buildKey(String keyPrefix, String fileBaseName, String extension) {
         String normalizedRoot = trimSlashes(audioRootPath);


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #16 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

워밍업 단계의 나만의 문장 음성 파일 조회 API를 구현했습니다.

### 구현 내용
- AI 음성 듣기 API 구현
- 내 음성 듣기 API 구현

### 세부 사항
- 선택한 문장에 대한 AI TTS 음성 URL 조회
- 사용자가 녹음한 음성 파일 URL 조회
- AccessToken 기반 로그인 사용자 식별
- 본인 소유 데이터 검증 로직 추가
- 삭제된 데이터 조회 제외 처리
- Swagger API 명세 작성
- 공통 응답 형식 적용

### API 목록
| Method | URL | 설명 |
|------|------|------|
| GET | `/warmups/my-sentences/{sentenceId}/ai-audio` | AI 음성 듣기 |
| GET | `/warmups/my-sentences/{sentenceId}/my-audio` | 내 음성 듣기 |

## 🧪 테스트 결과
> Apidog 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

- AI 음성 듣기 API
<img width="1432" height="1111" alt="image" src="https://github.com/user-attachments/assets/0cf1eb8b-155a-4a9a-8d07-dbfe36644367" />

- 내 음성 듣기 API
<img width="1233" height="1269" alt="image" src="https://github.com/user-attachments/assets/b8a180b0-d700-489b-a3fb-7e2a8f91f5d0" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

- 음성 파일은 저장된 URL을 반환하는 방식으로 구현했습니다.
- AI 음성과 사용자 음성 모두 동일한 응답 구조를 사용합니다.
- `Fix: 충돌 해결 및 MySentenceErrorCode 수정 (8371bef)` 커밋은 브랜치 병합 과정에서 발생한 충돌 해결 커밋으로 실제 기능 구현과는 무관하므로 리뷰 시 제외 부탁드립니다.