### PR TITLE
[Feat] 녹음 파일 업로드 및 발음 분석 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/client/HttpMySentenceAiClient.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/client/HttpMySentenceAiClient.java
@@ -1,6 +1,8 @@
 package com.kwcapstone.server.domain.mysentence.client;
 
 import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceTtsReqDTO;
+import com.kwcapstone.server.domain.mysentence.dto.request.PronunciationAnalyzeAiReqDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.PronunciationAnalyzeAiResDTO;
 import com.kwcapstone.server.domain.mysentence.exception.code.MySentenceErrorCode;
 import com.kwcapstone.server.global.apiPayload.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,21 @@ public class HttpMySentenceAiClient implements MySentenceAiClient {
                     .body(byte[].class);
         } catch (Exception e) {
             throw new CustomException(MySentenceErrorCode.TTS_GENERATION_FAILED);
+        }
+    }
+
+    @Override
+    public PronunciationAnalyzeAiResDTO analyzePronunciation(
+            PronunciationAnalyzeAiReqDTO request
+    ) {
+        try {
+            return aiRestClient.post()
+                    .uri("/practice/reference")
+                    .body(request)
+                    .retrieve()
+                    .body(PronunciationAnalyzeAiResDTO.class);
+        } catch (Exception e) {
+            throw new CustomException(MySentenceErrorCode.PRONUNCIATION_ANALYSIS_FAILED);
         }
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/client/MySentenceAiClient.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/client/MySentenceAiClient.java
@@ -1,7 +1,10 @@
 package com.kwcapstone.server.domain.mysentence.client;
 
 import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceTtsReqDTO;
+import com.kwcapstone.server.domain.mysentence.dto.request.PronunciationAnalyzeAiReqDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.PronunciationAnalyzeAiResDTO;
 
 public interface MySentenceAiClient {
-    byte[] requestTts(MySentenceTtsReqDTO request);
+    byte[] requestTts(MySentenceTtsReqDTO request);  // TTS
+    PronunciationAnalyzeAiResDTO analyzePronunciation(PronunciationAnalyzeAiReqDTO request);  // 발음 분석
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/controller/MySentenceAudioController.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/controller/MySentenceAudioController.java
@@ -1,5 +1,6 @@
 package com.kwcapstone.server.domain.mysentence.controller;
 
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceAnalyzeResDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceTtsResDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceUserAudioResDTO;
 import com.kwcapstone.server.domain.mysentence.service.MySentenceAudioService;
@@ -7,10 +8,9 @@ import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
 import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,6 +35,21 @@ public class MySentenceAudioController {
     ) {
         MySentenceUserAudioResDTO result =
                 mySentenceAudioService.getUserAudio(sentenceId);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    @Operation(summary = " 녹음 파일 업로드 및 발음 분석")
+    @PostMapping(
+            value = "/{sentenceId}/pronunciations/analyze",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public ApiResponse<MySentenceAnalyzeResDTO> analyzePronunciation(
+            @PathVariable Long sentenceId,
+            @RequestPart("voiceFile") MultipartFile voiceFile
+    ) {
+        MySentenceAnalyzeResDTO result =
+                mySentenceAudioService.analyzePronunciation(sentenceId, voiceFile);
 
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/converter/MySentenceConverter.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/converter/MySentenceConverter.java
@@ -2,10 +2,9 @@ package com.kwcapstone.server.domain.mysentence.converter;
 
 import com.kwcapstone.server.domain.member.entity.Member;
 import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceCreateReqDTO;
-import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceCreateResDTO;
-import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceDetailResDTO;
-import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceListResDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.*;
 import com.kwcapstone.server.domain.mysentence.entity.MySentence;
+import com.kwcapstone.server.domain.mysentence.entity.MySentenceAnalysisResult;
 
 import java.util.List;
 
@@ -47,6 +46,27 @@ public class MySentenceConverter {
         return new MySentenceDetailResDTO(
                 mySentence.getId(),
                 mySentence.getSentenceContent()
+        );
+    }
+
+    public static MySentenceAnalyzeResDTO toAnalyzeResponse(
+            MySentenceAnalysisResult result,
+            PronunciationAnalyzeAiResDTO aiResponse
+    ) {
+        return new MySentenceAnalyzeResDTO(
+                result.getId(),
+                result.getMySentence().getId(),
+                result.getPronunciationScore(),
+                result.getSpeechRateScore(),
+                result.getSilenceRatio(),
+                result.getAiFeedback(),
+                aiResponse.getWordAnalysis().stream()
+                        .map(word -> new MySentenceAnalyzeResDTO.WordAnalysis(
+                                word.getRefChar(),
+                                word.getHypChar(),
+                                word.getGrade()
+                        ))
+                        .toList()
         );
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/dto/request/PronunciationAnalyzeAiReqDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/dto/request/PronunciationAnalyzeAiReqDTO.java
@@ -1,0 +1,11 @@
+package com.kwcapstone.server.domain.mysentence.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PronunciationAnalyzeAiReqDTO {
+    private String s3Url;
+    private String referenceText;
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/MySentenceAnalyzeResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/MySentenceAnalyzeResDTO.java
@@ -1,0 +1,29 @@
+package com.kwcapstone.server.domain.mysentence.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MySentenceAnalyzeResDTO {
+    private Long analysisId;
+    private Long sentenceId;
+    private BigDecimal pronunciationScore;
+    private BigDecimal speechRateScore;
+    private BigDecimal silenceRatio;
+    private String aiFeedback;
+
+    private List<WordAnalysis> wordAnalysis;
+
+    @Getter
+    @AllArgsConstructor
+    public static class WordAnalysis {
+        private String refChar;
+        private String hypChar;
+        private String grade;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/PronunciationAnalyzeAiResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/dto/response/PronunciationAnalyzeAiResDTO.java
@@ -1,0 +1,53 @@
+package com.kwcapstone.server.domain.mysentence.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PronunciationAnalyzeAiResDTO {
+
+    private Boolean success;
+    private String referenceText;
+    private String sttText;
+    private String acousticText;
+    private BigDecimal pronunciationScore;
+    private String feedback;
+    private List<WordAnalysis> wordAnalysis;
+    private VoiceAnalysis voiceAnalysis;
+
+    @Getter
+    @NoArgsConstructor
+    public static class WordAnalysis {
+        private String refChar;
+        private String hypChar;
+        private String grade;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class VoiceAnalysis {
+        private SpeechRate speechRate;
+        private SilenceRatio silenceRatio;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class SpeechRate {
+        private BigDecimal syllablesPerSecond;
+        private BigDecimal score;
+        private String grade;
+        private String label;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class SilenceRatio {
+        private BigDecimal pausePercent;
+        private String grade;
+        private String label;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/entity/MySentenceAnalysisResult.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/entity/MySentenceAnalysisResult.java
@@ -30,7 +30,7 @@ public class MySentenceAnalysisResult extends BaseEntity {
     @Column(name = "pronunciation_score", nullable = false, precision = 5, scale = 2)
     private BigDecimal pronunciationScore;
 
-    @Column(name = "speech_rate_score", nullable = false, precision = 4, scale = 2)
+    @Column(name = "speech_rate_score", nullable = false, precision = 5, scale = 2)
     private BigDecimal speechRateScore;
 
     @Column(name = "silence_ratio", nullable = false, precision = 5, scale = 2)

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/exception/code/MySentenceErrorCode.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/exception/code/MySentenceErrorCode.java
@@ -12,12 +12,16 @@ public enum MySentenceErrorCode implements BaseCode {
     // 4xx
     EMPTY_SENTENCE_CONTENT(HttpStatus.BAD_REQUEST, "WARMUP_400_1", "문장 내용이 비어있습니다."),
     SENTENCE_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "WARMUP_400_2", "문장 길이를 초과했습니다."),
+    AUDIO_FILE_REQUIRED(HttpStatus.BAD_REQUEST, "WARMUP400_3", "오디오 파일이 없습니다."),
+    UNSUPPORTED_AUDIO_FORMAT(HttpStatus.BAD_REQUEST, "WARMUP400_4", "지원하지 않는 오디오 형식입니다."),
+    AUDIO_TOO_SHORT(HttpStatus.BAD_REQUEST, "WARMUP400_5", "오디오 길이가 너무 짧습니다."),
     MY_SENTENCE_FORBIDDEN(HttpStatus.FORBIDDEN, "WARMUP_403", "본인의 문장이 아니어서 삭제할 수 없습니다."),
     MY_SENTENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "WARMUP_404_1", "존재하지 않거나 이미 삭제된 문장입니다."),
     RECENT_USER_AUDIO_NOT_FOUND(HttpStatus.NOT_FOUND, "WARMUP_404_2", "최근 녹음 음성이 없습니다."),
 
     // 5xx
-    TTS_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WARMUP_500", "TTS 생성에 실패했습니다.")
+    TTS_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WARMUP_500", "TTS 생성에 실패했습니다."),
+    PRONUNCIATION_ANALYSIS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WARMUP500_2", "발음 분석에 실패했습니다.")
     ;
 
 

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceAudioService.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceAudioService.java
@@ -1,9 +1,12 @@
 package com.kwcapstone.server.domain.mysentence.service;
 
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceAnalyzeResDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceTtsResDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceUserAudioResDTO;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface MySentenceAudioService {
     MySentenceTtsResDTO getTts(Long sentenceId);  // TTS
     MySentenceUserAudioResDTO getUserAudio(Long sentenceId);  // user audio
+    MySentenceAnalyzeResDTO analyzePronunciation(Long sentenceId, MultipartFile voiceFile);  // 발음 분석
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceAudioServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/service/MySentenceAudioServiceImpl.java
@@ -1,9 +1,13 @@
 package com.kwcapstone.server.domain.mysentence.service;
 
 import com.kwcapstone.server.domain.mysentence.client.MySentenceAiClient;
+import com.kwcapstone.server.domain.mysentence.converter.MySentenceConverter;
 import com.kwcapstone.server.domain.mysentence.dto.request.MySentenceTtsReqDTO;
+import com.kwcapstone.server.domain.mysentence.dto.request.PronunciationAnalyzeAiReqDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceAnalyzeResDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceTtsResDTO;
 import com.kwcapstone.server.domain.mysentence.dto.response.MySentenceUserAudioResDTO;
+import com.kwcapstone.server.domain.mysentence.dto.response.PronunciationAnalyzeAiResDTO;
 import com.kwcapstone.server.domain.mysentence.entity.MySentence;
 import com.kwcapstone.server.domain.mysentence.entity.MySentenceAnalysisResult;
 import com.kwcapstone.server.domain.mysentence.exception.code.MySentenceErrorCode;
@@ -15,6 +19,8 @@ import com.kwcapstone.server.global.storage.audio.AudioStorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import tools.jackson.databind.ObjectMapper;
 
 @Service
 @RequiredArgsConstructor
@@ -25,11 +31,14 @@ public class MySentenceAudioServiceImpl implements MySentenceAudioService {
     private static final String TTS_VOICE = "nova";
     private static final double TTS_SPEED = 1.0;
     private static final long PRESIGNED_EXPIRES_IN = 600L;
+    private static final long MAX_AUDIO_SIZE = 10 * 1024 * 1024;
 
     private final MySentenceRepository mySentenceRepository;
     private final MySentenceAiClient mySentenceAiClient;
     private final AudioStorageService audioStorageService;
     private final MySentenceAnalysisResultRepository mySentenceAnalysisResultRepository;
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public MySentenceTtsResDTO getTts(Long sentenceId) {
@@ -106,5 +115,100 @@ public class MySentenceAudioServiceImpl implements MySentenceAudioService {
                 userAudioUrl,
                 600L
         );
+    }
+
+    @Override
+    @Transactional
+    public MySentenceAnalyzeResDTO analyzePronunciation(
+            Long sentenceId,
+            MultipartFile voiceFile
+    ) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        validateVoiceFile(voiceFile);
+
+        MySentence mySentence = mySentenceRepository.findByIdAndDeletedAtIsNull(sentenceId)
+                .orElseThrow(() -> new CustomException(MySentenceErrorCode.MY_SENTENCE_NOT_FOUND));
+
+        if (!mySentence.getMember().getId().equals(memberId)) {
+            throw new CustomException(MySentenceErrorCode.MY_SENTENCE_FORBIDDEN);
+        }
+
+        String keyPrefix = "my-sentence/" + memberId;
+        String fileBaseName = "sentence-" + sentenceId + "-user-" + System.currentTimeMillis();
+
+        String userAudioKey = audioStorageService.upload(
+                keyPrefix,
+                fileBaseName,
+                voiceFile
+        );
+
+        String userAudioPresignedUrl =
+                audioStorageService.generatePresignedGetUrl(userAudioKey);
+
+        PronunciationAnalyzeAiResDTO aiResponse =
+                mySentenceAiClient.analyzePronunciation(
+                        new PronunciationAnalyzeAiReqDTO(
+                                userAudioPresignedUrl,
+                                mySentence.getSentenceContent()
+                        )
+                );
+
+        if (aiResponse == null || !Boolean.TRUE.equals(aiResponse.getSuccess())) {
+            throw new CustomException(MySentenceErrorCode.PRONUNCIATION_ANALYSIS_FAILED);
+        }
+
+        try {
+            String wordAnalysisJson = objectMapper.writeValueAsString(
+                    aiResponse.getWordAnalysis()
+            );
+
+            MySentenceAnalysisResult analysisResult =
+                    MySentenceAnalysisResult.builder()
+                            .mySentence(mySentence)
+                            .member(mySentence.getMember())
+                            .userAudioKey(userAudioKey)
+                            .pronunciationScore(aiResponse.getPronunciationScore())
+                            .speechRateScore(aiResponse.getVoiceAnalysis()
+                                    .getSpeechRate()
+                                    .getScore())
+                            .silenceRatio(aiResponse.getVoiceAnalysis()
+                                    .getSilenceRatio()
+                                    .getPausePercent())
+                            .aiFeedback(aiResponse.getFeedback())
+                            .syllableResultJson(wordAnalysisJson)
+                            .build();
+
+            MySentenceAnalysisResult savedResult =
+                    mySentenceAnalysisResultRepository.save(analysisResult);
+
+            return MySentenceConverter.toAnalyzeResponse(savedResult, aiResponse);
+
+        } catch (Exception e) {
+            throw new CustomException(MySentenceErrorCode.PRONUNCIATION_ANALYSIS_FAILED);
+        }
+    }
+
+    // 파일 검증 매서드
+    private void validateVoiceFile(MultipartFile voiceFile) {
+        if (voiceFile == null || voiceFile.isEmpty()) {
+            throw new CustomException(MySentenceErrorCode.AUDIO_FILE_REQUIRED);
+        }
+
+        if (voiceFile.getSize() > MAX_AUDIO_SIZE) {
+            throw new CustomException(MySentenceErrorCode.UNSUPPORTED_AUDIO_FORMAT);
+        }
+
+        String contentType = voiceFile.getContentType();
+
+        if (contentType == null ||
+                !(contentType.equals("audio/mpeg")
+                        || contentType.equals("audio/mp3")
+                        || contentType.equals("audio/wav")
+                        || contentType.equals("audio/webm")
+                        || contentType.equals("audio/x-m4a")
+                        || contentType.equals("audio/mp4"))) {
+            throw new CustomException(MySentenceErrorCode.UNSUPPORTED_AUDIO_FORMAT);
+        }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #17 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

워밍업 단계의 나만의 문장 녹음 파일 업로드 및 발음 분석 API를 구현했습니다.

### 구현 내용
- 녹음 파일 업로드 및 발음 분석 API 구현
- 사용자 음성 파일 S3 업로드
- FastAPI 기반 발음 분석 서버 연동
- 분석 결과 DB 저장

### 세부 사항
- MultipartFile 형태의 음성 파일 업로드 처리
- 선택한 문장의 referenceText와 함께 AI 서버로 전달
- AI 서버 응답 데이터를 Spring DTO로 매핑
- 발음 분석 결과(점수, 피드백, 단어별 분석 등) 저장
- 사용자 음성 URL 저장
- AccessToken 기반 로그인 사용자 식별
- 본인 소유 문장 검증 로직 추가
- Swagger API 명세 작성
- 공통 응답 형식 적용

### API 목록
| Method | URL | 설명 |
|------|------|------|
| POST | `/warmups/my-sentences/{sentenceId}/analyses` | 녹음 파일 업로드 및 발음 분석 |

## 🧪 테스트 결과
> Apidog 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

- 요청
<img width="1224" height="754" alt="image" src="https://github.com/user-attachments/assets/f5d28b88-ec9a-435a-9395-febd15ccd3bb" />

- 응답
<img width="1177" height="612" alt="image" src="https://github.com/user-attachments/assets/7c46714f-c199-4d17-b28d-16c214aae597" />

- FastAPI 요청
<img width="1195" height="1083" alt="image" src="https://github.com/user-attachments/assets/e3719f6c-2549-4759-8501-577676ab8b26" />

- FastAPI 응답
<img width="1156" height="616" alt="image" src="https://github.com/user-attachments/assets/e42e37ca-3eb7-47ee-8bcc-b98ef35c8c26" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.


## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

- AI 서버 응답 구조에 맞춰 DTO를 설계했습니다.
- 분석 결과는 추후 피드백 화면 및 재조회 API에서 활용할 수 있도록 저장했습니다.
- 음성 파일은 S3에 업로드 후 반환된 URL을 DB에 저장합니다.
- 외부 AI 서버 연동 실패에 대비하여 예외 처리를 추가했습니다.