### PR TITLE
[Feat] 시나리오 생성 및 조회 API 구현

### DIFF
--- a/src/main/java/com/kwcapstone/server/domain/scenario/client/HttpScenarioAiClient.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/client/HttpScenarioAiClient.java
@@ -1,0 +1,29 @@
+package com.kwcapstone.server.domain.scenario.client;
+
+import com.kwcapstone.server.domain.scenario.dto.request.ScenarioGenerateAiReqDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioGenerateAiResDTO;
+import com.kwcapstone.server.domain.scenario.exception.code.ScenarioErrorCode;
+import com.kwcapstone.server.global.apiPayload.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+public class HttpScenarioAiClient implements ScenarioAiClient {
+
+    private final RestClient aiRestClient;
+
+    @Override
+    public ScenarioGenerateAiResDTO generateScenario(ScenarioGenerateAiReqDTO request) {
+        try {
+            return aiRestClient.post()
+                    .uri("/generate-scenario")
+                    .body(request)
+                    .retrieve()
+                    .body(ScenarioGenerateAiResDTO.class);
+        } catch (Exception e) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_GENERATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/client/ScenarioAiClient.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/client/ScenarioAiClient.java
@@ -1,0 +1,8 @@
+package com.kwcapstone.server.domain.scenario.client;
+
+import com.kwcapstone.server.domain.scenario.dto.request.ScenarioGenerateAiReqDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioGenerateAiResDTO;
+
+public interface ScenarioAiClient {
+    ScenarioGenerateAiResDTO generateScenario(ScenarioGenerateAiReqDTO request);  // 시나리오 생성
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioCommandController.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioCommandController.java
@@ -1,0 +1,28 @@
+package com.kwcapstone.server.domain.scenario.controller;
+
+import com.kwcapstone.server.domain.scenario.dto.request.ScenarioCreateReqDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioCreateResDTO;
+import com.kwcapstone.server.domain.scenario.service.ScenarioCommandService;
+import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
+import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/conversations/scenarios")
+public class ScenarioCommandController {
+
+    private final ScenarioCommandService scenarioCommandService;
+
+    @Operation(summary = "시나리오 생성")
+    @PostMapping
+    public ApiResponse<ScenarioCreateResDTO> createScenario(
+            @RequestBody ScenarioCreateReqDTO request
+    ) {
+        ScenarioCreateResDTO result = scenarioCommandService.createScenario(request);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioQueryController.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioQueryController.java
@@ -1,5 +1,6 @@
 package com.kwcapstone.server.domain.scenario.controller;
 
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioDetailResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioListResDTO;
 import com.kwcapstone.server.domain.scenario.service.ScenarioQueryService;
 import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
@@ -19,6 +20,16 @@ public class ScenarioQueryController {
     @GetMapping
     public ApiResponse<ScenarioListResDTO> getScenarioList() {
         ScenarioListResDTO result = scenarioQueryService.getScenarioList();
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    @Operation(summary = "시나리오 상세 및 레벨 목록 조회")
+    @GetMapping("/{scenarioId}")
+    public ApiResponse<ScenarioDetailResDTO> getScenarioDetail(
+            @PathVariable Long scenarioId
+    ) {
+        ScenarioDetailResDTO result = scenarioQueryService.getScenarioDetail(scenarioId);
 
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioQueryController.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioQueryController.java
@@ -1,0 +1,25 @@
+package com.kwcapstone.server.domain.scenario.controller;
+
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioListResDTO;
+import com.kwcapstone.server.domain.scenario.service.ScenarioQueryService;
+import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
+import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/conversations/scenarios")
+public class ScenarioQueryController {
+
+    private final ScenarioQueryService scenarioQueryService;
+
+    @Operation(summary = "시나리오 목록 조회")
+    @GetMapping
+    public ApiResponse<ScenarioListResDTO> getScenarioList() {
+        ScenarioListResDTO result = scenarioQueryService.getScenarioList();
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/converter/ScenarioConverter.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/converter/ScenarioConverter.java
@@ -1,0 +1,88 @@
+package com.kwcapstone.server.domain.scenario.converter;
+
+import com.kwcapstone.server.domain.member.entity.Member;
+import com.kwcapstone.server.domain.scenario.dto.request.ScenarioCreateReqDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioCreateResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioGenerateAiResDTO;
+import com.kwcapstone.server.domain.scenario.entity.Scenario;
+import com.kwcapstone.server.domain.scenario.entity.ScenarioLevel;
+import com.kwcapstone.server.domain.scenario.entity.ScenarioStep;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+public class ScenarioConverter {
+
+    private ScenarioConverter() {
+    }
+
+    public static Scenario toScenario(
+            ScenarioCreateReqDTO request,
+            Member member,
+            ScenarioGenerateAiResDTO aiResponse
+    ) {
+        Scenario scenario = Scenario.builder()
+                .member(member)
+                .title(request.getTitle().trim())
+                .description(request.getDescription().trim())
+                .scenarioContext(aiResponse.getData().getScenarioContext())
+                .goal(aiResponse.getData().getGoal())
+                .build();
+
+        List<ScenarioGenerateAiResDTO.Level> aiLevels = aiResponse.getData().getLevels();
+
+        IntStream.range(0, aiLevels.size()).forEach(levelIndex -> {
+            ScenarioGenerateAiResDTO.Level aiLevel = aiLevels.get(levelIndex);
+
+            ScenarioLevel level = ScenarioLevel.builder()
+                    .levelNo(levelIndex + 1)
+                    .levelTitle(aiLevel.getLevelTitle())
+                    .levelDescription(aiLevel.getLevelDescription())
+                    .build();
+
+            List<ScenarioGenerateAiResDTO.Step> aiSteps = aiLevel.getSteps();
+
+            IntStream.range(0, aiSteps.size()).forEach(stepIndex -> {
+                ScenarioGenerateAiResDTO.Step aiStep = aiSteps.get(stepIndex);
+
+                ScenarioStep step = ScenarioStep.builder()
+                        .stepNo(stepIndex + 1)
+                        .stepName(aiStep.getStep())
+                        .assistantMessage(aiStep.getAssistantMessage())
+                        .userIntent(aiStep.getUserIntent())
+                        .build();
+
+                level.addStep(step);
+            });
+
+            scenario.addLevel(level);
+        });
+
+        return scenario;
+    }
+
+    public static ScenarioCreateResDTO toCreateResponse(Scenario scenario) {
+        List<ScenarioCreateResDTO.LevelInfo> levels = scenario.getLevels().stream()
+                .map(level -> new ScenarioCreateResDTO.LevelInfo(
+                        level.getLevelNo(),
+                        level.getLevelTitle(),
+                        level.getLevelDescription(),
+                        level.getSteps().stream()
+                                .map(step -> new ScenarioCreateResDTO.StepInfo(
+                                        step.getStepNo(),
+                                        step.getStepName(),
+                                        step.getAssistantMessage(),
+                                        step.getUserIntent()
+                                ))
+                                .toList()
+                ))
+                .toList();
+
+        return new ScenarioCreateResDTO(
+                scenario.getId(),
+                scenario.getTitle(),
+                scenario.getDescription(),
+                levels
+        );
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/converter/ScenarioConverter.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/converter/ScenarioConverter.java
@@ -3,6 +3,7 @@ package com.kwcapstone.server.domain.scenario.converter;
 import com.kwcapstone.server.domain.member.entity.Member;
 import com.kwcapstone.server.domain.scenario.dto.request.ScenarioCreateReqDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioCreateResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioDetailResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioGenerateAiResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioListResDTO;
 import com.kwcapstone.server.domain.scenario.entity.Scenario;
@@ -94,6 +95,24 @@ public class ScenarioConverter {
                                 scenario.getId(),
                                 scenario.getTitle(),
                                 scenario.getDescription()
+                        ))
+                        .toList()
+        );
+    }
+
+    public static ScenarioDetailResDTO toDetailResponse(
+            Scenario scenario,
+            List<ScenarioLevel> levels
+    ) {
+        return new ScenarioDetailResDTO(
+                scenario.getId(),
+                scenario.getTitle(),
+                scenario.getDescription(),
+                levels.stream()
+                        .map(level -> new ScenarioDetailResDTO.LevelInfo(
+                                level.getLevelNo(),
+                                level.getLevelTitle(),
+                                level.getLevelDescription()
                         ))
                         .toList()
         );

--- a/src/main/java/com/kwcapstone/server/domain/scenario/converter/ScenarioConverter.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/converter/ScenarioConverter.java
@@ -4,6 +4,7 @@ import com.kwcapstone.server.domain.member.entity.Member;
 import com.kwcapstone.server.domain.scenario.dto.request.ScenarioCreateReqDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioCreateResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioGenerateAiResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioListResDTO;
 import com.kwcapstone.server.domain.scenario.entity.Scenario;
 import com.kwcapstone.server.domain.scenario.entity.ScenarioLevel;
 import com.kwcapstone.server.domain.scenario.entity.ScenarioStep;
@@ -83,6 +84,18 @@ public class ScenarioConverter {
                 scenario.getTitle(),
                 scenario.getDescription(),
                 levels
+        );
+    }
+
+    public static ScenarioListResDTO toListResponse(List<Scenario> scenarios) {
+        return new ScenarioListResDTO(
+                scenarios.stream()
+                        .map(scenario -> new ScenarioListResDTO.ScenarioInfo(
+                                scenario.getId(),
+                                scenario.getTitle(),
+                                scenario.getDescription()
+                        ))
+                        .toList()
         );
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/dto/request/ScenarioCreateReqDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/dto/request/ScenarioCreateReqDTO.java
@@ -1,0 +1,11 @@
+package com.kwcapstone.server.domain.scenario.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ScenarioCreateReqDTO {
+    private String title;
+    private String description;
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/dto/request/ScenarioGenerateAiReqDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/dto/request/ScenarioGenerateAiReqDTO.java
@@ -1,0 +1,11 @@
+package com.kwcapstone.server.domain.scenario.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ScenarioGenerateAiReqDTO {
+    private String scenarioContext;
+    private String goal;
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioCreateResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioCreateResDTO.java
@@ -1,0 +1,37 @@
+package com.kwcapstone.server.domain.scenario.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScenarioCreateResDTO {
+    private Long scenarioId;
+    private String title;
+    private String description;
+    private List<LevelInfo> levels;
+
+    @Getter
+    @AllArgsConstructor
+    public static class LevelInfo{
+        private int level;
+        private String levelTitle;
+        private String levelDescription;
+        private List<StepInfo> steps;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class StepInfo{
+        private int stepNo;
+        private String step;
+        private String assistantMessage;
+        private String userIntent;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioDetailResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioDetailResDTO.java
@@ -1,0 +1,24 @@
+package com.kwcapstone.server.domain.scenario.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ScenarioDetailResDTO {
+
+    private Long scenarioId;
+    private String title;
+    private String description;
+    private List<LevelInfo> levels;
+
+    @Getter
+    @AllArgsConstructor
+    public static class LevelInfo {
+        private Integer level;
+        private String levelTitle;
+        private String levelDescription;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioGenerateAiResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioGenerateAiResDTO.java
@@ -1,0 +1,38 @@
+package com.kwcapstone.server.domain.scenario.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ScenarioGenerateAiResDTO {
+
+    private Boolean success;
+    private Data data;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Data {
+        private String scenarioContext;
+        private String goal;
+        private List<Level> levels;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Level {
+        private String levelTitle;
+        private String levelDescription;
+        private List<Step> steps;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Step {
+        private String step;
+        private String assistantMessage;
+        private String userIntent;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioListResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioListResDTO.java
@@ -1,0 +1,22 @@
+package com.kwcapstone.server.domain.scenario.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScenarioListResDTO {
+    private List<ScenarioInfo> scenarios;
+
+    @Getter
+    @AllArgsConstructor
+    public static class ScenarioInfo {
+        private Long scenarioId;
+        private String title;
+        private String description;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/entity/Scenario.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/entity/Scenario.java
@@ -1,0 +1,44 @@
+package com.kwcapstone.server.domain.scenario.entity;
+
+import com.kwcapstone.server.domain.member.entity.Member;
+import com.kwcapstone.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "scenario")
+@AttributeOverride(name = "id", column = @Column(name = "scenario_id"))
+public class Scenario extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "description", nullable = false, length = 255)
+    private String description;
+
+    @Column(name = "scenario_context", nullable = false, length = 100)
+    private String scenarioContext;
+
+    @Column(name = "goal", nullable = false, length = 255)
+    private String goal;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "scenario", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ScenarioLevel> levels = new ArrayList<>();
+
+    public void addLevel(ScenarioLevel level) {
+        this.levels.add(level);
+        level.setScenario(this);
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/entity/ScenarioLevel.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/entity/ScenarioLevel.java
@@ -1,0 +1,44 @@
+package com.kwcapstone.server.domain.scenario.entity;
+
+import com.kwcapstone.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "scenario_level")
+@AttributeOverride(name = "id", column = @Column(name = "scenario_level_id"))
+public class ScenarioLevel extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "scenario_id", nullable = false)
+    private Scenario scenario;
+
+    @Column(name = "level_no", nullable = false)
+    private Integer levelNo;
+
+    @Column(name = "level_title", nullable = false, length = 60)
+    private String levelTitle;
+
+    @Column(name = "level_description", nullable = false, length = 255)
+    private String levelDescription;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "scenarioLevel", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ScenarioStep> steps = new ArrayList<>();
+
+    public void setScenario(Scenario scenario) {
+        this.scenario = scenario;
+    }
+
+    public void addStep(ScenarioStep step) {
+        this.steps.add(step);
+        step.setScenarioLevel(this);
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/entity/ScenarioStep.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/entity/ScenarioStep.java
@@ -1,0 +1,35 @@
+package com.kwcapstone.server.domain.scenario.entity;
+
+import com.kwcapstone.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "scenario_step")
+@AttributeOverride(name = "id", column = @Column(name = "scenario_step_id"))
+public class ScenarioStep extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "scenario_level_id", nullable = false)
+    private ScenarioLevel scenarioLevel;
+
+    @Column(name = "step_no", nullable = false)
+    private Integer stepNo;
+
+    @Column(name = "step_name", nullable = false, length = 60)
+    private String stepName;
+
+    @Column(name = "assistant_message", nullable = false, length = 255)
+    private String assistantMessage;
+
+    @Column(name = "user_intent", nullable = false, length = 255)
+    private String userIntent;
+
+    public void setScenarioLevel(ScenarioLevel scenarioLevel) {
+        this.scenarioLevel = scenarioLevel;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/exception/code/ScenarioErrorCode.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/exception/code/ScenarioErrorCode.java
@@ -12,6 +12,9 @@ public enum ScenarioErrorCode implements BaseCode {
     // 4xx
     EMPTY_SCENARIO_TITLE(HttpStatus.BAD_REQUEST, "SCENAIRO_400_1", "시나리오 제목은 필수입니다."),
     EMPTY_SCENARIO_DESCRIPTION(HttpStatus.BAD_REQUEST, "SCENAIRO_400_2", "시나리오 상세 설명은 필수입니다."),
+    SCENARIO_FORBIDDEN(HttpStatus.FORBIDDEN, "SCENAIRO_403", "해당 시나리오에 접근할 수 없습니다."),
+    SCENARIO_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404", "시나리오를 찾을 수 없습니다."),
+
 
     // 5xx
     SCENARIO_GENERATION_FAILED(HttpStatus.BAD_GATEWAY, "SCENAIRO_502", "AI 서버 시나리오 생성에 실패했습니다.")

--- a/src/main/java/com/kwcapstone/server/domain/scenario/exception/code/ScenarioErrorCode.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/exception/code/ScenarioErrorCode.java
@@ -1,0 +1,24 @@
+package com.kwcapstone.server.domain.scenario.exception.code;
+
+import com.kwcapstone.server.global.apiPayload.response.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ScenarioErrorCode implements BaseCode {
+
+    // 4xx
+    EMPTY_SCENARIO_TITLE(HttpStatus.BAD_REQUEST, "SCENAIRO_400_1", "시나리오 제목은 필수입니다."),
+    EMPTY_SCENARIO_DESCRIPTION(HttpStatus.BAD_REQUEST, "SCENAIRO_400_2", "시나리오 상세 설명은 필수입니다."),
+
+    // 5xx
+    SCENARIO_GENERATION_FAILED(HttpStatus.BAD_GATEWAY, "SCENAIRO_502", "AI 서버 시나리오 생성에 실패했습니다.")
+    ;
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioLevelRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioLevelRepository.java
@@ -1,0 +1,10 @@
+package com.kwcapstone.server.domain.scenario.repository;
+
+import com.kwcapstone.server.domain.scenario.entity.ScenarioLevel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ScenarioLevelRepository extends JpaRepository<ScenarioLevel, Long> {
+    List<ScenarioLevel> findAllByScenarioIdOrderByLevelNoAsc(Long scenarioId);
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioRepository.java
@@ -1,0 +1,7 @@
+package com.kwcapstone.server.domain.scenario.repository;
+
+import com.kwcapstone.server.domain.scenario.entity.Scenario;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScenarioRepository extends JpaRepository<Scenario, Long> {
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioRepository.java
@@ -3,5 +3,8 @@ package com.kwcapstone.server.domain.scenario.repository;
 import com.kwcapstone.server.domain.scenario.entity.Scenario;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ScenarioRepository extends JpaRepository<Scenario, Long> {
+    List<Scenario> findAllByMemberIdOrderByCreatedAtDesc(Long memberId);
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioCommandService.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioCommandService.java
@@ -1,0 +1,8 @@
+package com.kwcapstone.server.domain.scenario.service;
+
+import com.kwcapstone.server.domain.scenario.dto.request.ScenarioCreateReqDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioCreateResDTO;
+
+public interface ScenarioCommandService {
+    ScenarioCreateResDTO createScenario(ScenarioCreateReqDTO request);  // 시나리오 생성
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioCommandServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioCommandServiceImpl.java
@@ -1,0 +1,84 @@
+package com.kwcapstone.server.domain.scenario.service;
+
+import com.kwcapstone.server.domain.member.entity.Member;
+import com.kwcapstone.server.domain.member.repository.MemberRepository;
+import com.kwcapstone.server.domain.scenario.client.ScenarioAiClient;
+import com.kwcapstone.server.domain.scenario.converter.ScenarioConverter;
+import com.kwcapstone.server.domain.scenario.dto.request.ScenarioCreateReqDTO;
+import com.kwcapstone.server.domain.scenario.dto.request.ScenarioGenerateAiReqDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioCreateResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioGenerateAiResDTO;
+import com.kwcapstone.server.domain.scenario.entity.Scenario;
+import com.kwcapstone.server.domain.scenario.exception.code.ScenarioErrorCode;
+import com.kwcapstone.server.domain.scenario.repository.ScenarioRepository;
+import com.kwcapstone.server.global.apiPayload.exception.CustomException;
+import com.kwcapstone.server.global.apiPayload.response.ErrorCode;
+import com.kwcapstone.server.global.security.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ScenarioCommandServiceImpl implements ScenarioCommandService {
+
+    private final ScenarioRepository scenarioRepository;
+    private final MemberRepository memberRepository;
+    private final ScenarioAiClient scenarioAiClient;
+
+    @Override
+    public ScenarioCreateResDTO createScenario(ScenarioCreateReqDTO request) {
+        validateCreateRequest(request);
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
+
+        ScenarioGenerateAiResDTO aiResponse = scenarioAiClient.generateScenario(
+                new ScenarioGenerateAiReqDTO(
+                        request.getTitle().trim(),
+                        request.getDescription().trim()
+                )
+        );
+
+        validateAiResponse(aiResponse);
+
+        Scenario scenario = ScenarioConverter.toScenario(request, member, aiResponse);
+        Scenario savedScenario = scenarioRepository.save(scenario);
+
+        return ScenarioConverter.toCreateResponse(savedScenario);
+    }
+
+    private void validateCreateRequest(ScenarioCreateReqDTO request) {
+        if (request.getTitle() == null || request.getTitle().trim().isEmpty()) {
+            throw new CustomException(ScenarioErrorCode.EMPTY_SCENARIO_TITLE);
+        }
+
+        if (request.getDescription() == null || request.getDescription().trim().isEmpty()) {
+            throw new CustomException(ScenarioErrorCode.EMPTY_SCENARIO_DESCRIPTION);
+        }
+    }
+
+    private void validateAiResponse(ScenarioGenerateAiResDTO aiResponse) {
+        if (aiResponse == null || !Boolean.TRUE.equals(aiResponse.getSuccess())) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_GENERATION_FAILED);
+        }
+
+        if (aiResponse.getData() == null || aiResponse.getData().getLevels() == null) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_GENERATION_FAILED);
+        }
+
+        if (aiResponse.getData().getLevels().size() != 3) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_GENERATION_FAILED);
+        }
+
+        boolean hasInvalidStepCount = aiResponse.getData().getLevels().stream()
+                .anyMatch(level -> level.getSteps() == null || level.getSteps().size() != 3);
+
+        if (hasInvalidStepCount) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_GENERATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryService.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryService.java
@@ -1,7 +1,9 @@
 package com.kwcapstone.server.domain.scenario.service;
 
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioDetailResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioListResDTO;
 
 public interface ScenarioQueryService {
     ScenarioListResDTO getScenarioList();  // 시나리오 목록 조히
+    ScenarioDetailResDTO getScenarioDetail(Long scenarioId);  // 시나리오 상세 조회 및 레벨 조회
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryService.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryService.java
@@ -1,0 +1,7 @@
+package com.kwcapstone.server.domain.scenario.service;
+
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioListResDTO;
+
+public interface ScenarioQueryService {
+    ScenarioListResDTO getScenarioList();  // 시나리오 목록 조히
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryServiceImpl.java
@@ -1,9 +1,14 @@
 package com.kwcapstone.server.domain.scenario.service;
 
 import com.kwcapstone.server.domain.scenario.converter.ScenarioConverter;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioDetailResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioListResDTO;
 import com.kwcapstone.server.domain.scenario.entity.Scenario;
+import com.kwcapstone.server.domain.scenario.entity.ScenarioLevel;
+import com.kwcapstone.server.domain.scenario.exception.code.ScenarioErrorCode;
+import com.kwcapstone.server.domain.scenario.repository.ScenarioLevelRepository;
 import com.kwcapstone.server.domain.scenario.repository.ScenarioRepository;
+import com.kwcapstone.server.global.apiPayload.exception.CustomException;
 import com.kwcapstone.server.global.security.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +22,7 @@ import java.util.List;
 public class ScenarioQueryServiceImpl implements ScenarioQueryService {
 
     private final ScenarioRepository scenarioRepository;
+    private final ScenarioLevelRepository scenarioLevelRepository;
 
     @Override
     public ScenarioListResDTO getScenarioList() {
@@ -26,5 +32,22 @@ public class ScenarioQueryServiceImpl implements ScenarioQueryService {
                 scenarioRepository.findAllByMemberIdOrderByCreatedAtDesc(memberId);
 
         return ScenarioConverter.toListResponse(scenarios);
+    }
+
+    @Override
+    public ScenarioDetailResDTO getScenarioDetail(Long scenarioId) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        Scenario scenario = scenarioRepository.findById(scenarioId)
+                .orElseThrow(() -> new CustomException(ScenarioErrorCode.SCENARIO_NOT_FOUND));
+
+        if (!scenario.getMember().getId().equals(memberId)) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_FORBIDDEN);
+        }
+
+        List<ScenarioLevel> levels =
+                scenarioLevelRepository.findAllByScenarioIdOrderByLevelNoAsc(scenarioId);
+
+        return ScenarioConverter.toDetailResponse(scenario, levels);
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryServiceImpl.java
@@ -1,0 +1,30 @@
+package com.kwcapstone.server.domain.scenario.service;
+
+import com.kwcapstone.server.domain.scenario.converter.ScenarioConverter;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioListResDTO;
+import com.kwcapstone.server.domain.scenario.entity.Scenario;
+import com.kwcapstone.server.domain.scenario.repository.ScenarioRepository;
+import com.kwcapstone.server.global.security.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScenarioQueryServiceImpl implements ScenarioQueryService {
+
+    private final ScenarioRepository scenarioRepository;
+
+    @Override
+    public ScenarioListResDTO getScenarioList() {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        List<Scenario> scenarios =
+                scenarioRepository.findAllByMemberIdOrderByCreatedAtDesc(memberId);
+
+        return ScenarioConverter.toListResponse(scenarios);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #24 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

시나리오 생성 및 조회 API를 구현했습니다.

### 구현 내용
- 시나리오 생성 API 구현
- 시나리오 목록 조회 API 구현
- 시나리오 상세 및 레벨 목록 조회 API 구현

### 세부 사항
- 로그인 사용자 기준 시나리오 생성
- AI 서버를 통한 시나리오 생성 결과 연동
- 생성된 시나리오 및 레벨 정보 DB 저장
- 로그인 사용자의 시나리오 목록 조회
- 선택한 시나리오 상세 정보 및 레벨 목록 조회
- 본인 소유 시나리오 검증 로직 추가
- 삭제된 시나리오 조회 제외 처리
- Swagger API 문서 작성
- 공통 응답 형식 적용

### API 목록
| Method | URL | 설명 |
|------|------|------|
| POST | `/api/conversations/scenarios` | 시나리오 생성 |
| GET | `/api/conversations/scenarios` | 시나리오 목록 조회 |
| GET | `/api/conversations/scenarios/{scenarioId}` | 시나리오 상세 및 레벨 목록 조회 |

## 🧪 테스트 결과
> Apidog 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

-  시나리오 생성 API 요청
<img width="1231" height="1041" alt="image" src="https://github.com/user-attachments/assets/1fd3797a-6bde-4647-a0eb-eef6ce466827" />

- 시나리오 생성 API 응답
<img width="1204" height="687" alt="image" src="https://github.com/user-attachments/assets/900bc13a-5926-41da-abec-b764db4af98d" />

- 시나리오 조회 API
<img width="1218" height="1180" alt="image" src="https://github.com/user-attachments/assets/7c23cc69-05c5-4629-a005-8e1019cdbdfb" />

- 시나리오 상세 및 레벨 목록 조회 API 요청
<img width="1219" height="427" alt="image" src="https://github.com/user-attachments/assets/54930aab-47c8-4aa7-aad2-7c9605472738" />

- 시나리오 상세 및 레벨 목록 조회 API 응답 
<img width="1218" height="546" alt="image" src="https://github.com/user-attachments/assets/6fb4e334-d92b-47c6-b5c1-f1e42bc82328" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.

- 시나리오 상세 및 레벨 목록 조회 API 404 Error
<img width="1225" height="1021" alt="image" src="https://github.com/user-attachments/assets/fb56a0db-9594-4b0b-aa55-8dda69be2da3" />


## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

- 시나리오 생성 시 AI 서버 응답 구조에 맞춰 시나리오와 레벨 정보를 저장합니다.
- 이후 단계 조회, 음성 답변 분석, 훈련 결과 조회 API에서 재사용할 수 있도록 시나리오/레벨 데이터를 분리해 저장했습니다.