### PR TITLE
[Feat] 시나리오 대화 단계 조회 API 구현

### DIFF
--- a/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioQueryController.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioQueryController.java
@@ -2,6 +2,7 @@ package com.kwcapstone.server.domain.scenario.controller;
 
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioDetailResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioListResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioStepDetailResDTO;
 import com.kwcapstone.server.domain.scenario.service.ScenarioQueryService;
 import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
 import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
@@ -30,6 +31,19 @@ public class ScenarioQueryController {
             @PathVariable Long scenarioId
     ) {
         ScenarioDetailResDTO result = scenarioQueryService.getScenarioDetail(scenarioId);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    @Operation(summary = "대화 단계 조회")
+    @GetMapping("/{scenarioId}/levels/{level}/steps/{stepNo}")
+    public ApiResponse<ScenarioStepDetailResDTO> getScenarioStep(
+            @PathVariable Long scenarioId,
+            @PathVariable Integer level,
+            @PathVariable Integer stepNo
+    ) {
+        ScenarioStepDetailResDTO result =
+                scenarioQueryService.getScenarioStep(scenarioId, level, stepNo);
 
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/converter/ScenarioConverter.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/converter/ScenarioConverter.java
@@ -2,10 +2,7 @@ package com.kwcapstone.server.domain.scenario.converter;
 
 import com.kwcapstone.server.domain.member.entity.Member;
 import com.kwcapstone.server.domain.scenario.dto.request.ScenarioCreateReqDTO;
-import com.kwcapstone.server.domain.scenario.dto.response.ScenarioCreateResDTO;
-import com.kwcapstone.server.domain.scenario.dto.response.ScenarioDetailResDTO;
-import com.kwcapstone.server.domain.scenario.dto.response.ScenarioGenerateAiResDTO;
-import com.kwcapstone.server.domain.scenario.dto.response.ScenarioListResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.*;
 import com.kwcapstone.server.domain.scenario.entity.Scenario;
 import com.kwcapstone.server.domain.scenario.entity.ScenarioLevel;
 import com.kwcapstone.server.domain.scenario.entity.ScenarioStep;
@@ -115,6 +112,26 @@ public class ScenarioConverter {
                                 level.getLevelDescription()
                         ))
                         .toList()
+        );
+    }
+
+    public static ScenarioStepDetailResDTO toStepDetailResponse(
+            Scenario scenario,
+            ScenarioLevel level,
+            ScenarioStep step,
+            Long totalStepCount,
+            Boolean isAnswered
+    ) {
+        return new ScenarioStepDetailResDTO(
+                scenario.getId(),
+                level.getLevelNo(),
+                step.getStepNo(),
+                totalStepCount,
+                level.getLevelTitle(),
+                step.getStepName(),
+                step.getAssistantMessage(),
+                step.getUserIntent(),
+                isAnswered
         );
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioStepDetailResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioStepDetailResDTO.java
@@ -1,0 +1,21 @@
+package com.kwcapstone.server.domain.scenario.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ScenarioStepDetailResDTO {
+
+    private Long scenarioId;
+    private Integer level;
+    private Integer stepNo;
+    private Long totalStepCount;
+
+    private String levelTitle;
+    private String step;
+    private String assistantMessage;
+    private String userIntent;
+
+    private Boolean isAnswered;
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/entity/ScenarioAnalysisResult.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/entity/ScenarioAnalysisResult.java
@@ -1,0 +1,47 @@
+package com.kwcapstone.server.domain.scenario.entity;
+
+import com.kwcapstone.server.domain.member.entity.Member;
+import com.kwcapstone.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "scenario_analysis_result")
+@AttributeOverride(name = "id", column = @Column(name = "scenario_analysis_result_id"))
+public class ScenarioAnalysisResult extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "scenario_step_id", nullable = false)
+    private ScenarioStep scenarioStep;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "user_audio_key", length = 500)
+    private String userAudioKey;
+
+    @Column(name = "pronunciation_score", nullable = false, precision = 5, scale = 2)
+    private BigDecimal pronunciationScore;
+
+    @Column(name = "meaning_delivery_score", nullable = false, precision = 5, scale = 2)
+    private BigDecimal meaningDeliveryScore;
+
+    @Column(name = "speech_rate_score", precision = 5, scale = 2)
+    private BigDecimal speechRateScore;
+
+    @Column(name = "silence_ratio", precision = 5, scale = 2)
+    private BigDecimal silenceRatio;
+
+    @Column(name = "ai_feedback", columnDefinition = "TEXT")
+    private String aiFeedback;
+
+    @Column(name = "word_analysis_json", nullable = false, columnDefinition = "TEXT")
+    private String wordAnalysisJson;
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/exception/code/ScenarioErrorCode.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/exception/code/ScenarioErrorCode.java
@@ -12,9 +12,11 @@ public enum ScenarioErrorCode implements BaseCode {
     // 4xx
     EMPTY_SCENARIO_TITLE(HttpStatus.BAD_REQUEST, "SCENAIRO_400_1", "시나리오 제목은 필수입니다."),
     EMPTY_SCENARIO_DESCRIPTION(HttpStatus.BAD_REQUEST, "SCENAIRO_400_2", "시나리오 상세 설명은 필수입니다."),
+    INVALID_LEVEL(HttpStatus.BAD_REQUEST, "SCENAIRO_400_3", "유효하지 않은 레벨입니다."),
+    INVALID_STEP(HttpStatus.BAD_REQUEST, "SCENARIO_400_4", "유효하지 않은 단계입니다."),
     SCENARIO_FORBIDDEN(HttpStatus.FORBIDDEN, "SCENAIRO_403", "해당 시나리오에 접근할 수 없습니다."),
-    SCENARIO_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404", "시나리오를 찾을 수 없습니다."),
-
+    SCENARIO_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404_1", "시나리오를 찾을 수 없습니다."),
+    SCENARIO_STEP_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404_2", "대화 단계를 찾을 수 없습니다."),
 
     // 5xx
     SCENARIO_GENERATION_FAILED(HttpStatus.BAD_GATEWAY, "SCENAIRO_502", "AI 서버 시나리오 생성에 실패했습니다.")

--- a/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioAnalysisResultRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioAnalysisResultRepository.java
@@ -1,0 +1,8 @@
+package com.kwcapstone.server.domain.scenario.repository;
+
+import com.kwcapstone.server.domain.scenario.entity.ScenarioAnalysisResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScenarioAnalysisResultRepository extends JpaRepository<ScenarioAnalysisResult, Long> {
+    boolean existsByScenarioStepIdAndMemberId(Long scenarioStepId, Long memberId);
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioLevelRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioLevelRepository.java
@@ -4,7 +4,9 @@ import com.kwcapstone.server.domain.scenario.entity.ScenarioLevel;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ScenarioLevelRepository extends JpaRepository<ScenarioLevel, Long> {
     List<ScenarioLevel> findAllByScenarioIdOrderByLevelNoAsc(Long scenarioId);
+    Optional<ScenarioLevel> findByScenarioIdAndLevelNo(Long scenarioId, Integer levelNo);
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioStepRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioStepRepository.java
@@ -1,0 +1,11 @@
+package com.kwcapstone.server.domain.scenario.repository;
+
+import com.kwcapstone.server.domain.scenario.entity.ScenarioStep;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ScenarioStepRepository extends JpaRepository<ScenarioStep, Long> {
+    Optional<ScenarioStep> findByScenarioLevelIdAndStepNo(Long scenarioLevelId, Integer stepNo);
+    long countByScenarioLevelId(Long scenarioLevelId);
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryService.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryService.java
@@ -2,8 +2,10 @@ package com.kwcapstone.server.domain.scenario.service;
 
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioDetailResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioListResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioStepDetailResDTO;
 
 public interface ScenarioQueryService {
     ScenarioListResDTO getScenarioList();  // 시나리오 목록 조히
     ScenarioDetailResDTO getScenarioDetail(Long scenarioId);  // 시나리오 상세 조회 및 레벨 조회
+    ScenarioStepDetailResDTO getScenarioStep(Long scenarioId, Integer level, Integer stepNo);  // 시나리오 단계 조회
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryServiceImpl.java
@@ -3,11 +3,15 @@ package com.kwcapstone.server.domain.scenario.service;
 import com.kwcapstone.server.domain.scenario.converter.ScenarioConverter;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioDetailResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioListResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioStepDetailResDTO;
 import com.kwcapstone.server.domain.scenario.entity.Scenario;
 import com.kwcapstone.server.domain.scenario.entity.ScenarioLevel;
+import com.kwcapstone.server.domain.scenario.entity.ScenarioStep;
 import com.kwcapstone.server.domain.scenario.exception.code.ScenarioErrorCode;
+import com.kwcapstone.server.domain.scenario.repository.ScenarioAnalysisResultRepository;
 import com.kwcapstone.server.domain.scenario.repository.ScenarioLevelRepository;
 import com.kwcapstone.server.domain.scenario.repository.ScenarioRepository;
+import com.kwcapstone.server.domain.scenario.repository.ScenarioStepRepository;
 import com.kwcapstone.server.global.apiPayload.exception.CustomException;
 import com.kwcapstone.server.global.security.SecurityUtil;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +27,8 @@ public class ScenarioQueryServiceImpl implements ScenarioQueryService {
 
     private final ScenarioRepository scenarioRepository;
     private final ScenarioLevelRepository scenarioLevelRepository;
+    private final ScenarioStepRepository scenarioStepRepository;
+    private final ScenarioAnalysisResultRepository scenarioAnalysisResultRepository;
 
     @Override
     public ScenarioListResDTO getScenarioList() {
@@ -49,5 +55,57 @@ public class ScenarioQueryServiceImpl implements ScenarioQueryService {
                 scenarioLevelRepository.findAllByScenarioIdOrderByLevelNoAsc(scenarioId);
 
         return ScenarioConverter.toDetailResponse(scenario, levels);
+    }
+
+    @Override
+    public ScenarioStepDetailResDTO getScenarioStep(
+            Long scenarioId,
+            Integer level,
+            Integer stepNo
+    ) {
+        validateLevel(level);
+        validateStep(stepNo);
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        Scenario scenario = scenarioRepository.findById(scenarioId)
+                .orElseThrow(() -> new CustomException(ScenarioErrorCode.SCENARIO_NOT_FOUND));
+
+        if (!scenario.getMember().getId().equals(memberId)) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_FORBIDDEN);
+        }
+
+        ScenarioLevel scenarioLevel = scenarioLevelRepository
+                .findByScenarioIdAndLevelNo(scenarioId, level)
+                .orElseThrow(() -> new CustomException(ScenarioErrorCode.SCENARIO_STEP_NOT_FOUND));
+
+        ScenarioStep scenarioStep = scenarioStepRepository
+                .findByScenarioLevelIdAndStepNo(scenarioLevel.getId(), stepNo)
+                .orElseThrow(() -> new CustomException(ScenarioErrorCode.SCENARIO_STEP_NOT_FOUND));
+
+        Long totalStepCount = scenarioStepRepository.countByScenarioLevelId(scenarioLevel.getId());
+
+        Boolean isAnswered = scenarioAnalysisResultRepository
+                .existsByScenarioStepIdAndMemberId(scenarioStep.getId(), memberId);
+
+        return ScenarioConverter.toStepDetailResponse(
+                scenario,
+                scenarioLevel,
+                scenarioStep,
+                totalStepCount,
+                isAnswered
+        );
+    }
+
+    private void validateLevel(Integer level) {
+        if (level == null || level < 1 || level > 3) {
+            throw new CustomException(ScenarioErrorCode.INVALID_LEVEL);
+        }
+    }
+
+    private void validateStep(Integer stepNo) {
+        if (stepNo == null || stepNo < 1 || stepNo > 3) {
+            throw new CustomException(ScenarioErrorCode.INVALID_STEP);
+        }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #25 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

시나리오 단계 조회 API를 구현했습니다.

### 구현 내용
- 대화 단계 조회 API 구현

### 세부 사항
- 로그인 사용자의 시나리오 접근 권한 검증
- `scenarioId`, `level`, `stepNo`에 해당하는 대화 단계 조회
- 단계별 대화 정보 반환
  - levelTitle
  - step
  - assistantMessage
  - userIntent
  - hint
  - totalStepCount
  - isAnswered
- 응답 DTO 작성
- Swagger API 문서 작성
- 공통 응답 형식 적용

### API 목록
| Method | URL | 설명 |
|------|------|------|
| GET | `/api/conversations/scenarios/{scenarioId}/levels/{level}/steps/{stepNo}` | 대화 단계 조회 |


## 🧪 테스트 결과
> Apidog 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

- 시나리오 level 1 step 3
<img width="715" height="569" alt="image" src="https://github.com/user-attachments/assets/e31b3ca7-7ba6-4b0f-bfc9-0dce6b0ce89a" />

- 시나리오 level 2 step 2
<img width="719" height="575" alt="image" src="https://github.com/user-attachments/assets/79a2accc-7f83-490e-9839-c20d2ea8e9d6" />

- 시나리오 level 3 step 1
<img width="724" height="571" alt="image" src="https://github.com/user-attachments/assets/f7ffe01c-d58f-4540-a967-e99592be82b9" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.

- error 처리
<img width="724" height="506" alt="image" src="https://github.com/user-attachments/assets/c7e9c42e-8a14-413a-9787-79b14ce3cfc8" />
<img width="716" height="508" alt="image" src="https://github.com/user-attachments/assets/943712fe-afc0-4a77-bfcd-5fe4868c12a4" />


## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

- AI 서버에서 생성된 시나리오 데이터(3개 레벨 × 각 레벨당 3개 단계)를 기반으로 조회합니다.
- 단계별 학습 진행 여부(`isAnswered`)를 함께 반환하도록 구현했습니다.