### PR TITLE
[Feat] 시나리오 음성 답변 분석 및 사용자 음성 조회 API 구현

### DIFF
--- a/src/main/java/com/kwcapstone/server/domain/scenario/client/HttpScenarioAiClient.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/client/HttpScenarioAiClient.java
@@ -1,7 +1,9 @@
 package com.kwcapstone.server.domain.scenario.client;
 
 import com.kwcapstone.server.domain.scenario.dto.request.ScenarioGenerateAiReqDTO;
+import com.kwcapstone.server.domain.scenario.dto.request.ScenarioPracticeAiReqDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioGenerateAiResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioPracticeAiResDTO;
 import com.kwcapstone.server.domain.scenario.exception.code.ScenarioErrorCode;
 import com.kwcapstone.server.global.apiPayload.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,24 @@ public class HttpScenarioAiClient implements ScenarioAiClient {
                     .body(ScenarioGenerateAiResDTO.class);
         } catch (Exception e) {
             throw new CustomException(ScenarioErrorCode.SCENARIO_GENERATION_FAILED);
+        }
+    }
+
+    @Override
+    public ScenarioPracticeAiResDTO practiceScenario(
+            ScenarioPracticeAiReqDTO request
+    ) {
+        try {
+            return aiRestClient.post()
+                    .uri("/practice/scenario")
+                    .body(request)
+                    .retrieve()
+                    .body(ScenarioPracticeAiResDTO.class);
+
+        } catch (Exception e) {
+            throw new CustomException(
+                    ScenarioErrorCode.SCENARIO_ANALYSIS_FAILED
+            );
         }
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/client/ScenarioAiClient.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/client/ScenarioAiClient.java
@@ -1,8 +1,11 @@
 package com.kwcapstone.server.domain.scenario.client;
 
 import com.kwcapstone.server.domain.scenario.dto.request.ScenarioGenerateAiReqDTO;
+import com.kwcapstone.server.domain.scenario.dto.request.ScenarioPracticeAiReqDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioGenerateAiResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioPracticeAiResDTO;
 
 public interface ScenarioAiClient {
     ScenarioGenerateAiResDTO generateScenario(ScenarioGenerateAiReqDTO request);  // 시나리오 생성
+    ScenarioPracticeAiResDTO practiceScenario(ScenarioPracticeAiReqDTO request);  // 음성 파일 분석
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioAudioController.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioAudioController.java
@@ -1,6 +1,7 @@
 package com.kwcapstone.server.domain.scenario.controller;
 
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioAnswerAnalyzeResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioUserAudioResDTO;
 import com.kwcapstone.server.domain.scenario.service.ScenarioAudioService;
 import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
 import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
@@ -34,6 +35,23 @@ public class ScenarioAudioController {
                         level,
                         stepNo,
                         voiceFile
+                );
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    @Operation(summary = "시나리오 내 음성 듣기")
+    @GetMapping("/{scenarioId}/levels/{level}/steps/{stepNo}/user-audio")
+    public ApiResponse<ScenarioUserAudioResDTO> getScenarioUserAudio(
+            @PathVariable Long scenarioId,
+            @PathVariable Integer level,
+            @PathVariable Integer stepNo
+    ) {
+        ScenarioUserAudioResDTO result =
+                scenarioAudioService.getScenarioUserAudio(
+                        scenarioId,
+                        level,
+                        stepNo
                 );
 
         return ApiResponse.onSuccess(result, SuccessCode.OK);

--- a/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioAudioController.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioAudioController.java
@@ -1,0 +1,41 @@
+package com.kwcapstone.server.domain.scenario.controller;
+
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioAnswerAnalyzeResDTO;
+import com.kwcapstone.server.domain.scenario.service.ScenarioAudioService;
+import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
+import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/conversations/scenarios")
+public class ScenarioAudioController {
+
+    private final ScenarioAudioService scenarioAudioService;
+
+    @Operation(summary = "녹음 파일 업로드 및 시나리오 음성 답변 분석")
+    @PostMapping(
+            value = "/{scenarioId}/levels/{level}/steps/{stepNo}/answers",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public ApiResponse<ScenarioAnswerAnalyzeResDTO> analyzeScenarioAnswer(
+            @PathVariable Long scenarioId,
+            @PathVariable Integer level,
+            @PathVariable Integer stepNo,
+            @RequestPart("voiceFile") MultipartFile voiceFile
+    ) {
+        ScenarioAnswerAnalyzeResDTO result =
+                scenarioAudioService.analyzeScenarioAnswer(
+                        scenarioId,
+                        level,
+                        stepNo,
+                        voiceFile
+                );
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/converter/ScenarioConverter.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/converter/ScenarioConverter.java
@@ -4,6 +4,7 @@ import com.kwcapstone.server.domain.member.entity.Member;
 import com.kwcapstone.server.domain.scenario.dto.request.ScenarioCreateReqDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.*;
 import com.kwcapstone.server.domain.scenario.entity.Scenario;
+import com.kwcapstone.server.domain.scenario.entity.ScenarioAnalysisResult;
 import com.kwcapstone.server.domain.scenario.entity.ScenarioLevel;
 import com.kwcapstone.server.domain.scenario.entity.ScenarioStep;
 
@@ -133,5 +134,39 @@ public class ScenarioConverter {
                 step.getUserIntent(),
                 isAnswered
         );
+    }
+
+    public static ScenarioAnalysisResult toScenarioAnalysisResult(
+            ScenarioStep scenarioStep,
+            Member member,
+            String userAudioKey,
+            String wordAnalysisJson,
+            ScenarioPracticeAiResDTO aiResponse
+    ) {
+        return ScenarioAnalysisResult.builder()
+                .scenarioStep(scenarioStep)
+                .member(member)
+                .userAudioKey(userAudioKey)
+
+                .pronunciationScore(aiResponse.getPronunciationScore())
+                .meaningDeliveryScore(aiResponse.getMeaningDeliveryScore())
+
+                .speechRateScore(
+                        aiResponse.getVoiceAnalysis()
+                                .getSpeechRate()
+                                .getScore()
+                )
+
+                .silenceRatio(
+                        aiResponse.getVoiceAnalysis()
+                                .getSilenceRatio()
+                                .getPausePercent()
+                )
+
+                .aiFeedback(aiResponse.getFeedback())
+
+                .wordAnalysisJson(wordAnalysisJson)
+
+                .build();
     }
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/dto/request/ScenarioPracticeAiReqDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/dto/request/ScenarioPracticeAiReqDTO.java
@@ -1,0 +1,14 @@
+package com.kwcapstone.server.domain.scenario.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ScenarioPracticeAiReqDTO {
+    private String s3Url;
+    private String levelTitle;
+    private String step;
+    private String assistantMessage;
+    private String userIntent;
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioAnswerAnalyzeResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioAnswerAnalyzeResDTO.java
@@ -1,0 +1,38 @@
+package com.kwcapstone.server.domain.scenario.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ScenarioAnswerAnalyzeResDTO {
+
+    private Long answerId;
+    private Long scenarioId;
+
+    private Integer level;
+    private Integer stepNo;
+
+    private BigDecimal pronunciationScore;
+    private BigDecimal meaningDeliveryScore;
+    private BigDecimal speechRateScore;
+    private BigDecimal silenceRatio;
+
+    private String feedback;
+
+    private Boolean isLastStep;
+    private Integer nextStepNo;
+
+    private List<WordAnalysis> wordAnalysis;
+
+    @Getter
+    @AllArgsConstructor
+    public static class WordAnalysis {
+        private String refChar;
+        private String hypChar;
+        private String grade;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioPracticeAiResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioPracticeAiResDTO.java
@@ -1,0 +1,62 @@
+package com.kwcapstone.server.domain.scenario.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ScenarioPracticeAiResDTO {
+
+    private Boolean success;
+
+    private String levelTitle;
+    private String step;
+
+    private String referenceText;
+    private String sttText;
+    private String acousticText;
+
+    private BigDecimal pronunciationScore;
+    private BigDecimal meaningDeliveryScore;
+
+    private String feedback;
+
+    private List<WordAnalysis> wordAnalysis;
+
+    private VoiceAnalysis voiceAnalysis;
+
+    @Getter
+    @NoArgsConstructor
+    public static class WordAnalysis {
+        private String refChar;
+        private String hypChar;
+        private String grade;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class VoiceAnalysis {
+        private SpeechRate speechRate;
+        private SilenceRatio silenceRatio;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class SpeechRate {
+        private BigDecimal syllablesPerSecond;
+        private BigDecimal score;
+        private String grade;
+        private String label;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class SilenceRatio {
+        private BigDecimal pausePercent;
+        private String grade;
+        private String label;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioUserAudioResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioUserAudioResDTO.java
@@ -1,0 +1,15 @@
+package com.kwcapstone.server.domain.scenario.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ScenarioUserAudioResDTO {
+    private Long answerId;
+    private Long scenarioId;
+    private Integer level;
+    private Integer stepNo;
+    private String userAudioUrl;
+    private Integer expiresIn;
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/exception/code/ScenarioErrorCode.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/exception/code/ScenarioErrorCode.java
@@ -19,6 +19,7 @@ public enum ScenarioErrorCode implements BaseCode {
     SCENARIO_FORBIDDEN(HttpStatus.FORBIDDEN, "SCENAIRO_403", "해당 시나리오에 접근할 수 없습니다."),
     SCENARIO_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404_1", "시나리오를 찾을 수 없습니다."),
     SCENARIO_STEP_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404_2", "대화 단계를 찾을 수 없습니다."),
+    USER_AUDIO_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404_3", "저장된 음성 파일을 찾을 수 없습니다."),
 
     // 5xx
     SCENARIO_GENERATION_FAILED(HttpStatus.BAD_GATEWAY, "SCENAIRO_502_1", "AI 서버 시나리오 생성에 실패했습니다."),

--- a/src/main/java/com/kwcapstone/server/domain/scenario/exception/code/ScenarioErrorCode.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/exception/code/ScenarioErrorCode.java
@@ -14,12 +14,15 @@ public enum ScenarioErrorCode implements BaseCode {
     EMPTY_SCENARIO_DESCRIPTION(HttpStatus.BAD_REQUEST, "SCENAIRO_400_2", "시나리오 상세 설명은 필수입니다."),
     INVALID_LEVEL(HttpStatus.BAD_REQUEST, "SCENAIRO_400_3", "유효하지 않은 레벨입니다."),
     INVALID_STEP(HttpStatus.BAD_REQUEST, "SCENARIO_400_4", "유효하지 않은 단계입니다."),
+    AUDIO_FILE_REQUIRED(HttpStatus.BAD_REQUEST, "SCENARIO_400_5", "음성 파일은 필수입니다."),
+    UNSUPPORTED_AUDIO_FORMAT(HttpStatus.BAD_REQUEST, "SCENARIO_400_6", "지원하지 않는 음성 파일 형식입니다."),
     SCENARIO_FORBIDDEN(HttpStatus.FORBIDDEN, "SCENAIRO_403", "해당 시나리오에 접근할 수 없습니다."),
     SCENARIO_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404_1", "시나리오를 찾을 수 없습니다."),
     SCENARIO_STEP_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404_2", "대화 단계를 찾을 수 없습니다."),
 
     // 5xx
-    SCENARIO_GENERATION_FAILED(HttpStatus.BAD_GATEWAY, "SCENAIRO_502", "AI 서버 시나리오 생성에 실패했습니다.")
+    SCENARIO_GENERATION_FAILED(HttpStatus.BAD_GATEWAY, "SCENAIRO_502_1", "AI 서버 시나리오 생성에 실패했습니다."),
+    SCENARIO_ANALYSIS_FAILED(HttpStatus.BAD_GATEWAY, "SCENARIO_502_2", "AI 서버 음성 분석에 실패했습니다.")
     ;
 
 

--- a/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioAnalysisResultRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioAnalysisResultRepository.java
@@ -3,6 +3,9 @@ package com.kwcapstone.server.domain.scenario.repository;
 import com.kwcapstone.server.domain.scenario.entity.ScenarioAnalysisResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ScenarioAnalysisResultRepository extends JpaRepository<ScenarioAnalysisResult, Long> {
     boolean existsByScenarioStepIdAndMemberId(Long scenarioStepId, Long memberId);
+    Optional<ScenarioAnalysisResult> findTopByScenarioStepIdAndMemberIdOrderByCreatedAtDesc(Long scenarioStepId, Long memberId);
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioAudioService.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioAudioService.java
@@ -1,8 +1,10 @@
 package com.kwcapstone.server.domain.scenario.service;
 
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioAnswerAnalyzeResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioUserAudioResDTO;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ScenarioAudioService {
     ScenarioAnswerAnalyzeResDTO analyzeScenarioAnswer(Long scenarioId, Integer level, Integer stepNo, MultipartFile voiceFile);  // 음성 파일 분석
+    ScenarioUserAudioResDTO getScenarioUserAudio(Long scenarioId, Integer level, Integer stepNo);  // 내 음성 듣기
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioAudioService.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioAudioService.java
@@ -1,0 +1,8 @@
+package com.kwcapstone.server.domain.scenario.service;
+
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioAnswerAnalyzeResDTO;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ScenarioAudioService {
+    ScenarioAnswerAnalyzeResDTO analyzeScenarioAnswer(Long scenarioId, Integer level, Integer stepNo, MultipartFile voiceFile);  // 음성 파일 분석
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioAudioServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioAudioServiceImpl.java
@@ -1,0 +1,207 @@
+package com.kwcapstone.server.domain.scenario.service;
+
+import com.kwcapstone.server.domain.member.entity.Member;
+import com.kwcapstone.server.domain.member.repository.MemberRepository;
+import com.kwcapstone.server.domain.scenario.client.ScenarioAiClient;
+import com.kwcapstone.server.domain.scenario.dto.request.ScenarioPracticeAiReqDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioAnswerAnalyzeResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioPracticeAiResDTO;
+import com.kwcapstone.server.domain.scenario.entity.Scenario;
+import com.kwcapstone.server.domain.scenario.entity.ScenarioAnalysisResult;
+import com.kwcapstone.server.domain.scenario.entity.ScenarioLevel;
+import com.kwcapstone.server.domain.scenario.entity.ScenarioStep;
+import com.kwcapstone.server.domain.scenario.exception.code.ScenarioErrorCode;
+import com.kwcapstone.server.domain.scenario.repository.ScenarioAnalysisResultRepository;
+import com.kwcapstone.server.domain.scenario.repository.ScenarioLevelRepository;
+import com.kwcapstone.server.domain.scenario.repository.ScenarioRepository;
+import com.kwcapstone.server.domain.scenario.repository.ScenarioStepRepository;
+import com.kwcapstone.server.global.apiPayload.exception.CustomException;
+import com.kwcapstone.server.global.apiPayload.response.ErrorCode;
+import com.kwcapstone.server.global.security.SecurityUtil;
+import com.kwcapstone.server.global.storage.audio.S3AudioStorageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import tools.jackson.databind.ObjectMapper;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ScenarioAudioServiceImpl implements ScenarioAudioService {
+
+    private final ScenarioRepository scenarioRepository;
+    private final ScenarioLevelRepository scenarioLevelRepository;
+    private final ScenarioStepRepository scenarioStepRepository;
+    private final ScenarioAnalysisResultRepository scenarioAnalysisResultRepository;
+    private final MemberRepository memberRepository;
+
+    private final ScenarioAiClient scenarioAiClient;
+    private final S3AudioStorageService s3AudioStorageService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public ScenarioAnswerAnalyzeResDTO analyzeScenarioAnswer(
+            Long scenarioId,
+            Integer level,
+            Integer stepNo,
+            MultipartFile voiceFile
+    ) {
+        validateLevel(level);
+        validateStep(stepNo);
+        validateVoiceFile(voiceFile);
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
+
+        Scenario scenario = scenarioRepository.findById(scenarioId)
+                .orElseThrow(() -> new CustomException(ScenarioErrorCode.SCENARIO_NOT_FOUND));
+
+        if (!scenario.getMember().getId().equals(memberId)) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_FORBIDDEN);
+        }
+
+        ScenarioLevel scenarioLevel = scenarioLevelRepository
+                .findByScenarioIdAndLevelNo(scenarioId, level)
+                .orElseThrow(() -> new CustomException(ScenarioErrorCode.SCENARIO_STEP_NOT_FOUND));
+
+        ScenarioStep scenarioStep = scenarioStepRepository
+                .findByScenarioLevelIdAndStepNo(scenarioLevel.getId(), stepNo)
+                .orElseThrow(() -> new CustomException(ScenarioErrorCode.SCENARIO_STEP_NOT_FOUND));
+
+        String userAudioKey = uploadVoiceFile(
+                memberId,
+                scenarioId,
+                level,
+                stepNo,
+                voiceFile
+        );
+
+        String presignedUrl = s3AudioStorageService.generatePresignedGetUrl(userAudioKey);
+
+        ScenarioPracticeAiResDTO aiResponse = scenarioAiClient.practiceScenario(
+                new ScenarioPracticeAiReqDTO(
+                        presignedUrl,
+                        scenarioLevel.getLevelTitle(),
+                        scenarioStep.getStepName(),
+                        scenarioStep.getAssistantMessage(),
+                        scenarioStep.getUserIntent()
+                )
+        );
+
+        validateAiResponse(aiResponse);
+
+        ScenarioAnalysisResult analysisResult = ScenarioAnalysisResult.builder()
+                .scenarioStep(scenarioStep)
+                .member(member)
+                .userAudioKey(userAudioKey)
+                .pronunciationScore(aiResponse.getPronunciationScore())
+                .meaningDeliveryScore(aiResponse.getMeaningDeliveryScore())
+                .speechRateScore(aiResponse.getVoiceAnalysis().getSpeechRate().getScore())
+                .silenceRatio(aiResponse.getVoiceAnalysis().getSilenceRatio().getPausePercent())
+                .aiFeedback(aiResponse.getFeedback())
+                .wordAnalysisJson(toJson(aiResponse.getWordAnalysis()))
+                .build();
+
+        ScenarioAnalysisResult saved = scenarioAnalysisResultRepository.save(analysisResult);
+
+        boolean isLastStep = stepNo.equals(3);
+        Integer nextStepNo = isLastStep ? null : stepNo + 1;
+
+        return new ScenarioAnswerAnalyzeResDTO(
+                saved.getId(),
+                scenario.getId(),
+                level,
+                stepNo,
+                aiResponse.getPronunciationScore(),
+                aiResponse.getMeaningDeliveryScore(),
+                aiResponse.getVoiceAnalysis().getSpeechRate().getScore(),
+                aiResponse.getVoiceAnalysis().getSilenceRatio().getPausePercent(),
+                aiResponse.getFeedback(),
+                isLastStep,
+                nextStepNo,
+                aiResponse.getWordAnalysis().stream()
+                        .map(word -> new ScenarioAnswerAnalyzeResDTO.WordAnalysis(
+                                word.getRefChar(),
+                                word.getHypChar(),
+                                word.getGrade()
+                        ))
+                        .toList()
+        );
+    }
+
+    // level 값이 1~3 범위 내에 있는지 검증
+    private void validateLevel(Integer level) {
+        if (level == null || level < 1 || level > 3) {
+            throw new CustomException(ScenarioErrorCode.INVALID_LEVEL);
+        }
+    }
+
+    // stepNo 값이 1~3 범위 내에 있는지 검증
+    private void validateStep(Integer stepNo) {
+        if (stepNo == null || stepNo < 1 || stepNo > 3) {
+            throw new CustomException(ScenarioErrorCode.INVALID_STEP);
+        }
+    }
+
+    // 파일 검증 매서드
+    private void validateVoiceFile(MultipartFile voiceFile) {
+        if (voiceFile == null || voiceFile.isEmpty()) {
+            throw new CustomException(ScenarioErrorCode.AUDIO_FILE_REQUIRED);
+        }
+
+        String contentType = voiceFile.getContentType();
+
+        if (contentType == null ||
+                !(contentType.equals("audio/wav")
+                        || contentType.equals("audio/x-wav")
+                        || contentType.equals("audio/mpeg")
+                        || contentType.equals("audio/mp3")
+                        || contentType.equals("audio/mp4")
+                        || contentType.equals("audio/m4a"))) {
+            throw new CustomException(ScenarioErrorCode.UNSUPPORTED_AUDIO_FORMAT);
+        }
+    }
+
+    // AI 서버 응답이 정상이며 필수 분석 결과가 모두 포함되어 있는지 검증
+    private void validateAiResponse(ScenarioPracticeAiResDTO aiResponse) {
+        if (aiResponse == null || !Boolean.TRUE.equals(aiResponse.getSuccess())) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_ANALYSIS_FAILED);
+        }
+
+        if (aiResponse.getVoiceAnalysis() == null
+                || aiResponse.getVoiceAnalysis().getSpeechRate() == null
+                || aiResponse.getVoiceAnalysis().getSilenceRatio() == null
+                || aiResponse.getWordAnalysis() == null) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_ANALYSIS_FAILED);
+        }
+    }
+
+    // json 변환
+    private String toJson(Object object) {
+        try {
+            return objectMapper.writeValueAsString(object);
+        } catch (Exception e) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_ANALYSIS_FAILED);
+        }
+    }
+
+    // 사용자 음성 파일을 S3에 업로드하고 저장된 객체 키를 반환
+    private String uploadVoiceFile(
+            Long memberId,
+            Long scenarioId,
+            Integer level,
+            Integer stepNo,
+            MultipartFile voiceFile
+    ) {
+        return s3AudioStorageService.upload(
+                "conversation/" + memberId,
+                "scenario-" + scenarioId
+                        + "-level-" + level
+                        + "-step-" + stepNo,
+                voiceFile
+        );
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioAudioServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioAudioServiceImpl.java
@@ -6,6 +6,7 @@ import com.kwcapstone.server.domain.scenario.client.ScenarioAiClient;
 import com.kwcapstone.server.domain.scenario.dto.request.ScenarioPracticeAiReqDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioAnswerAnalyzeResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioPracticeAiResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioUserAudioResDTO;
 import com.kwcapstone.server.domain.scenario.entity.Scenario;
 import com.kwcapstone.server.domain.scenario.entity.ScenarioAnalysisResult;
 import com.kwcapstone.server.domain.scenario.entity.ScenarioLevel;
@@ -129,6 +130,57 @@ public class ScenarioAudioServiceImpl implements ScenarioAudioService {
                                 word.getGrade()
                         ))
                         .toList()
+        );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ScenarioUserAudioResDTO getScenarioUserAudio(
+            Long scenarioId,
+            Integer level,
+            Integer stepNo
+    ) {
+        validateLevel(level);
+        validateStep(stepNo);
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        Scenario scenario = scenarioRepository.findById(scenarioId)
+                .orElseThrow(() -> new CustomException(ScenarioErrorCode.SCENARIO_NOT_FOUND));
+
+        if (!scenario.getMember().getId().equals(memberId)) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_FORBIDDEN);
+        }
+
+        ScenarioLevel scenarioLevel = scenarioLevelRepository
+                .findByScenarioIdAndLevelNo(scenarioId, level)
+                .orElseThrow(() -> new CustomException(ScenarioErrorCode.SCENARIO_STEP_NOT_FOUND));
+
+        ScenarioStep scenarioStep = scenarioStepRepository
+                .findByScenarioLevelIdAndStepNo(scenarioLevel.getId(), stepNo)
+                .orElseThrow(() -> new CustomException(ScenarioErrorCode.SCENARIO_STEP_NOT_FOUND));
+
+        ScenarioAnalysisResult analysisResult = scenarioAnalysisResultRepository
+                .findTopByScenarioStepIdAndMemberIdOrderByCreatedAtDesc(
+                        scenarioStep.getId(),
+                        memberId
+                )
+                .orElseThrow(() -> new CustomException(ScenarioErrorCode.USER_AUDIO_NOT_FOUND));
+
+        if (analysisResult.getUserAudioKey() == null || analysisResult.getUserAudioKey().isBlank()) {
+            throw new CustomException(ScenarioErrorCode.USER_AUDIO_NOT_FOUND);
+        }
+
+        String userAudioUrl =
+                s3AudioStorageService.generatePresignedGetUrl(analysisResult.getUserAudioKey());
+
+        return new ScenarioUserAudioResDTO(
+                analysisResult.getId(),
+                scenario.getId(),
+                level,
+                stepNo,
+                userAudioUrl,
+                600
         );
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #26 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

시나리오 음성 답변 분석 및 사용자 음성 조회 API를 구현했습니다.

### 구현 내용
- 녹음 파일 업로드 및 시나리오 음성 답변 분석 API 구현
- 시나리오 내 음성 듣기 API 구현

### 세부 사항
- MultipartFile 형태의 음성 파일 업로드 처리
- 사용자 음성 파일 S3 업로드
- 선택한 단계의 referenceText, assistantMessage를 기반으로 AI 서버 호출
- AI 서버 응답 데이터를 DTO로 매핑
- 발음 분석 결과 DB 저장
- 단계별 답변 완료 상태 업데이트
- 최신 분석 결과의 `userAudioKey`를 기반으로 S3 Presigned URL 생성
- AccessToken 기반 로그인 사용자 식별
- 본인 소유 시나리오 검증 로직 추가
- Swagger API 문서 작성
- 공통 응답 형식 적용

### API 목록
| Method | URL | 설명 |
|------|------|------|
| POST | `/api/conversations/scenarios/{scenarioId}/levels/{level}/steps/{stepNo}/answers` | 녹음 파일 업로드 및 시나리오 음성 답변 분석 |
| GET | `/api/conversations/scenarios/{scenarioId}/levels/{level}/steps/{stepNo}/user-audio` | 시나리오 내 음성 듣기 |


## 🧪 테스트 결과
> Apidog 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

- 녹음 파일 업로드 및 음성 분석 API
<img width="1090" height="1189" alt="image" src="https://github.com/user-attachments/assets/d47f9f58-5c71-402d-936f-eff0249b2ef2" />

- 시나리오 내 음성 듣기 API
<img width="1441" height="1137" alt="image" src="https://github.com/user-attachments/assets/4245fd91-e076-41e7-8202-c6925a49b69e" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.

- 녹음 파일 업로드 및 음성 분석 API error 처리
<img width="722" height="640" alt="image" src="https://github.com/user-attachments/assets/d969809e-beb3-44a6-b0a7-508262523e50" />


## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

- 분석 결과는 추후 단계 재조회 및 레벨 결과 조회 API에서 재사용할 수 있도록 저장했습니다.
- 사용자 음성 파일은 S3에 저장하고, 재생 시 Presigned URL을 발급하여 반환합니다.
- 단계별 최신 분석 결과를 기준으로 사용자 음성을 조회하도록 구현했습니다.