### PR TITLE
[Feat] 시나리오 훈련 결과 조회 API 구현

### DIFF
--- a/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioQueryController.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioQueryController.java
@@ -1,6 +1,7 @@
 package com.kwcapstone.server.domain.scenario.controller;
 
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioDetailResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioLevelResultResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioListResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioStepDetailResDTO;
 import com.kwcapstone.server.domain.scenario.service.ScenarioQueryService;
@@ -44,6 +45,18 @@ public class ScenarioQueryController {
     ) {
         ScenarioStepDetailResDTO result =
                 scenarioQueryService.getScenarioStep(scenarioId, level, stepNo);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    @Operation(summary = "시나리오 훈련 완료 결과 조회")
+    @GetMapping("/{scenarioId}/levels/{level}/result")
+    public ApiResponse<ScenarioLevelResultResDTO> getScenarioLevelResult(
+            @PathVariable Long scenarioId,
+            @PathVariable Integer level
+    ) {
+        ScenarioLevelResultResDTO result =
+                scenarioQueryService.getScenarioLevelResult(scenarioId, level);
 
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioLevelResultResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioLevelResultResDTO.java
@@ -1,0 +1,18 @@
+package com.kwcapstone.server.domain.scenario.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class ScenarioLevelResultResDTO {
+    private Long scenarioId;
+    private Integer level;
+    private Integer totalStepCount;
+    private Integer completedStepCount;
+    private BigDecimal averagePronunciationScore;
+    private BigDecimal averageMeaningDeliveryScore;
+    private Boolean isCompleted;
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/exception/code/ScenarioErrorCode.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/exception/code/ScenarioErrorCode.java
@@ -20,6 +20,7 @@ public enum ScenarioErrorCode implements BaseCode {
     SCENARIO_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404_1", "시나리오를 찾을 수 없습니다."),
     SCENARIO_STEP_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404_2", "대화 단계를 찾을 수 없습니다."),
     USER_AUDIO_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404_3", "저장된 음성 파일을 찾을 수 없습니다."),
+    SCENARIO_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404_4", "훈련 결과를 찾을 수 없습니다."),
 
     // 5xx
     SCENARIO_GENERATION_FAILED(HttpStatus.BAD_GATEWAY, "SCENAIRO_502_1", "AI 서버 시나리오 생성에 실패했습니다."),

--- a/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioStepRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioStepRepository.java
@@ -3,9 +3,11 @@ package com.kwcapstone.server.domain.scenario.repository;
 import com.kwcapstone.server.domain.scenario.entity.ScenarioStep;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ScenarioStepRepository extends JpaRepository<ScenarioStep, Long> {
     Optional<ScenarioStep> findByScenarioLevelIdAndStepNo(Long scenarioLevelId, Integer stepNo);
     long countByScenarioLevelId(Long scenarioLevelId);
+    List<ScenarioStep> findAllByScenarioLevelIdOrderByStepNoAsc(Long scenarioLevelId);
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryService.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryService.java
@@ -1,6 +1,7 @@
 package com.kwcapstone.server.domain.scenario.service;
 
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioDetailResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioLevelResultResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioListResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioStepDetailResDTO;
 
@@ -8,4 +9,5 @@ public interface ScenarioQueryService {
     ScenarioListResDTO getScenarioList();  // 시나리오 목록 조히
     ScenarioDetailResDTO getScenarioDetail(Long scenarioId);  // 시나리오 상세 조회 및 레벨 조회
     ScenarioStepDetailResDTO getScenarioStep(Long scenarioId, Integer level, Integer stepNo);  // 시나리오 단계 조회
+    ScenarioLevelResultResDTO getScenarioLevelResult(Long scenarioId, Integer level);  // 시나리오 결과
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioQueryServiceImpl.java
@@ -2,9 +2,11 @@ package com.kwcapstone.server.domain.scenario.service;
 
 import com.kwcapstone.server.domain.scenario.converter.ScenarioConverter;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioDetailResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioLevelResultResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioListResDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioStepDetailResDTO;
 import com.kwcapstone.server.domain.scenario.entity.Scenario;
+import com.kwcapstone.server.domain.scenario.entity.ScenarioAnalysisResult;
 import com.kwcapstone.server.domain.scenario.entity.ScenarioLevel;
 import com.kwcapstone.server.domain.scenario.entity.ScenarioStep;
 import com.kwcapstone.server.domain.scenario.exception.code.ScenarioErrorCode;
@@ -18,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 
 @Service
@@ -97,15 +101,108 @@ public class ScenarioQueryServiceImpl implements ScenarioQueryService {
         );
     }
 
+    @Override
+    public ScenarioLevelResultResDTO getScenarioLevelResult(
+            Long scenarioId,
+            Integer level
+    ) {
+        validateLevel(level);
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        Scenario scenario = scenarioRepository.findById(scenarioId)
+                .orElseThrow(() -> new CustomException(ScenarioErrorCode.SCENARIO_NOT_FOUND));
+
+        if (!scenario.getMember().getId().equals(memberId)) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_FORBIDDEN);
+        }
+
+        ScenarioLevel scenarioLevel = scenarioLevelRepository
+                .findByScenarioIdAndLevelNo(scenarioId, level)
+                .orElseThrow(() -> new CustomException(ScenarioErrorCode.SCENARIO_RESULT_NOT_FOUND));
+
+        List<ScenarioStep> steps =
+                scenarioStepRepository.findAllByScenarioLevelIdOrderByStepNoAsc(
+                        scenarioLevel.getId()
+                );
+
+        if (steps.isEmpty()) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_RESULT_NOT_FOUND);
+        }
+
+        List<ScenarioAnalysisResult> results = steps.stream()
+                .map(step -> scenarioAnalysisResultRepository
+                        .findTopByScenarioStepIdAndMemberIdOrderByCreatedAtDesc(
+                                step.getId(),
+                                memberId
+                        )
+                        .orElse(null)
+                )
+                .filter(result -> result != null)
+                .toList();
+
+        if (results.isEmpty()) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_RESULT_NOT_FOUND);
+        }
+
+        int totalStepCount = steps.size();
+        int completedStepCount = results.size();
+
+        BigDecimal averagePronunciationScore = calculateAveragePronunciationScore(results);
+        BigDecimal averageMeaningDeliveryScore = calculateAverageMeaningDeliveryScore(results);
+
+        return new ScenarioLevelResultResDTO(
+                scenario.getId(),
+                level,
+                totalStepCount,
+                completedStepCount,
+                averagePronunciationScore,
+                averageMeaningDeliveryScore,
+                completedStepCount == totalStepCount
+        );
+    }
+
+    // level 값이 1~3 범위 내에 있는지 검증
     private void validateLevel(Integer level) {
         if (level == null || level < 1 || level > 3) {
             throw new CustomException(ScenarioErrorCode.INVALID_LEVEL);
         }
     }
 
+    // step 값이 1~3 범위 내에 있는지 검증
     private void validateStep(Integer stepNo) {
         if (stepNo == null || stepNo < 1 || stepNo > 3) {
             throw new CustomException(ScenarioErrorCode.INVALID_STEP);
         }
+    }
+
+    // 평균 발음 정확도 계산
+    private BigDecimal calculateAveragePronunciationScore(
+            List<ScenarioAnalysisResult> results
+    ) {
+        BigDecimal sum = results.stream()
+                .map(ScenarioAnalysisResult::getPronunciationScore)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return sum.divide(
+                BigDecimal.valueOf(results.size()),
+                0,
+                RoundingMode.HALF_UP
+        );
+    }
+
+    // 평균 의미 전달률 계산
+    private BigDecimal calculateAverageMeaningDeliveryScore(
+            List<ScenarioAnalysisResult> results
+    ) {
+        BigDecimal sum = results.stream()
+                .map(ScenarioAnalysisResult::getMeaningDeliveryScore)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return sum.divide(
+                BigDecimal.valueOf(results.size()),
+                0,
+                RoundingMode.HALF_UP
+        );
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #27 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

시나리오 훈련 완료 결과 조회 API를 구현했습니다.

### 구현 내용
- 시나리오 훈련 완료 결과 조회 API 구현

### 세부 사항
- 로그인 사용자의 시나리오 접근 권한 검증
- 특정 레벨의 모든 단계 분석 결과 조회
- 발음 정확도 평균 계산
- 의미 전달률 평균 계산
- 완료된 단계 수 계산
- 전체 단계 수 반환
- 레벨 완료 여부(`isCompleted`) 판단
- 응답 DTO 작성
- Swagger API 문서 작성
- 공통 응답 형식 적용

### API 목록
| Method | URL | 설명 |
|------|------|------|
| GET | `/api/conversations/scenarios/{scenarioId}/levels/{level}/result` | 시나리오 훈련 완료 결과 조회 |

## 🧪 테스트 결과
> Apidog 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="1665" height="1227" alt="image" src="https://github.com/user-attachments/assets/42ba7aae-a6db-4a9c-ac56-d7947ba93e2d" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.

- 훈련 결과 없을 시, error 
<img width="1659" height="1099" alt="image" src="https://github.com/user-attachments/assets/75c598a9-efe5-4d37-9de9-ed9c25e5812d" />


## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

- 총 3개의 단계가 모두 완료된 경우 `isCompleted = true`를 반환하도록 구현했습니다.
- 평균 점수는 소수점 반올림 처리하여 반환합니다.