### PR TITLE
[Feat] 시나리오 재생성 API 구현

### DIFF
--- a/src/main/java/com/kwcapstone/server/domain/scenario/client/HttpScenarioAiClient.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/client/HttpScenarioAiClient.java
@@ -2,6 +2,7 @@ package com.kwcapstone.server.domain.scenario.client;
 
 import com.kwcapstone.server.domain.scenario.client.dto.request.ScenarioGenerateAiReqDTO;
 import com.kwcapstone.server.domain.scenario.client.dto.request.ScenarioPracticeAiReqDTO;
+import com.kwcapstone.server.domain.scenario.client.dto.request.ScenarioRegenerateAiReqDTO;
 import com.kwcapstone.server.domain.scenario.client.dto.response.ScenarioGenerateAiResDTO;
 import com.kwcapstone.server.domain.scenario.client.dto.response.ScenarioPracticeAiResDTO;
 import com.kwcapstone.server.domain.scenario.exception.code.ScenarioErrorCode;
@@ -26,6 +27,19 @@ public class HttpScenarioAiClient implements ScenarioAiClient {
                     .body(ScenarioGenerateAiResDTO.class);
         } catch (Exception e) {
             throw new CustomException(ScenarioErrorCode.SCENARIO_GENERATION_FAILED);
+        }
+    }
+
+    @Override
+    public ScenarioGenerateAiResDTO regenerateScenarioStep(ScenarioRegenerateAiReqDTO request) {
+        try {
+            return aiRestClient.post()
+                    .uri("/regenerate-scenario-step")
+                    .body(request)
+                    .retrieve()
+                    .body(ScenarioGenerateAiResDTO.class);
+        } catch (Exception e) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_REGENERATION_FAILED);
         }
     }
 

--- a/src/main/java/com/kwcapstone/server/domain/scenario/client/ScenarioAiClient.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/client/ScenarioAiClient.java
@@ -2,10 +2,12 @@ package com.kwcapstone.server.domain.scenario.client;
 
 import com.kwcapstone.server.domain.scenario.client.dto.request.ScenarioGenerateAiReqDTO;
 import com.kwcapstone.server.domain.scenario.client.dto.request.ScenarioPracticeAiReqDTO;
+import com.kwcapstone.server.domain.scenario.client.dto.request.ScenarioRegenerateAiReqDTO;
 import com.kwcapstone.server.domain.scenario.client.dto.response.ScenarioGenerateAiResDTO;
 import com.kwcapstone.server.domain.scenario.client.dto.response.ScenarioPracticeAiResDTO;
 
 public interface ScenarioAiClient {
-    ScenarioGenerateAiResDTO generateScenario(ScenarioGenerateAiReqDTO request);  // 시나리오 생성
-    ScenarioPracticeAiResDTO practiceScenario(ScenarioPracticeAiReqDTO request);  // 음성 파일 분석
+    ScenarioGenerateAiResDTO generateScenario(ScenarioGenerateAiReqDTO request);
+    ScenarioGenerateAiResDTO regenerateScenarioStep(ScenarioRegenerateAiReqDTO request);
+    ScenarioPracticeAiResDTO practiceScenario(ScenarioPracticeAiReqDTO request);
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/client/dto/request/ScenarioRegenerateAiReqDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/client/dto/request/ScenarioRegenerateAiReqDTO.java
@@ -1,0 +1,33 @@
+package com.kwcapstone.server.domain.scenario.client.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ScenarioRegenerateAiReqDTO {
+
+    private String scenarioContext;
+    private String goal;
+    private List<Level> levels;
+    private Integer targetLevelIndex;
+    private Integer targetStepIndex;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Level {
+        private String levelTitle;
+        private String levelDescription;
+        private List<Step> steps;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Step {
+        private String step;
+        private String assistantMessage;
+        private String userIntent;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioCommandController.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/controller/ScenarioCommandController.java
@@ -2,6 +2,7 @@ package com.kwcapstone.server.domain.scenario.controller;
 
 import com.kwcapstone.server.domain.scenario.dto.request.ScenarioCreateReqDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioCreateResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioRegenerateResDTO;
 import com.kwcapstone.server.domain.scenario.service.ScenarioCommandService;
 import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
 import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
@@ -22,6 +23,19 @@ public class ScenarioCommandController {
             @RequestBody ScenarioCreateReqDTO request
     ) {
         ScenarioCreateResDTO result = scenarioCommandService.createScenario(request);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    @Operation(summary = "시나리오 단계 재생성")
+    @PostMapping("/{scenarioId}/levels/{level}/steps/{stepNo}/regenerate")
+    public ApiResponse<ScenarioRegenerateResDTO> regenerateScenarioStep(
+            @PathVariable Long scenarioId,
+            @PathVariable Integer level,
+            @PathVariable Integer stepNo
+    ) {
+        ScenarioRegenerateResDTO result =
+                scenarioCommandService.regenerateScenarioStep(scenarioId, level, stepNo);
 
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioRegenerateResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/dto/response/ScenarioRegenerateResDTO.java
@@ -1,0 +1,35 @@
+package com.kwcapstone.server.domain.scenario.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ScenarioRegenerateResDTO {
+
+    private Long scenarioId;
+    private String title;
+    private String description;
+    private RegeneratedFrom regeneratedFrom;
+    private CurrentStep currentStep;
+
+    @Getter
+    @AllArgsConstructor
+    public static class RegeneratedFrom {
+        private Integer level;
+        private Integer stepNo;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class CurrentStep {
+        private Long scenarioId;
+        private Integer level;
+        private Integer stepNo;
+        private String levelTitle;
+        private String step;
+        private String assistantMessage;
+        private String userIntent;
+        private Boolean isAnswered;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/scenario/entity/ScenarioLevel.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/entity/ScenarioLevel.java
@@ -41,4 +41,9 @@ public class ScenarioLevel extends BaseEntity {
         this.steps.add(step);
         step.setScenarioLevel(this);
     }
+
+    public void updateContent(String levelTitle, String levelDescription) {
+        this.levelTitle = levelTitle;
+        this.levelDescription = levelDescription;
+    }
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/entity/ScenarioStep.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/entity/ScenarioStep.java
@@ -32,4 +32,14 @@ public class ScenarioStep extends BaseEntity {
     public void setScenarioLevel(ScenarioLevel scenarioLevel) {
         this.scenarioLevel = scenarioLevel;
     }
+
+    public void updateContent(
+            String stepName,
+            String assistantMessage,
+            String userIntent
+    ) {
+        this.stepName = stepName;
+        this.assistantMessage = assistantMessage;
+        this.userIntent = userIntent;
+    }
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/exception/code/ScenarioErrorCode.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/exception/code/ScenarioErrorCode.java
@@ -16,7 +16,7 @@ public enum ScenarioErrorCode implements BaseCode {
     INVALID_STEP(HttpStatus.BAD_REQUEST, "SCENARIO_400_4", "유효하지 않은 단계입니다."),
     AUDIO_FILE_REQUIRED(HttpStatus.BAD_REQUEST, "SCENARIO_400_5", "음성 파일은 필수입니다."),
     UNSUPPORTED_AUDIO_FORMAT(HttpStatus.BAD_REQUEST, "SCENARIO_400_6", "지원하지 않는 음성 파일 형식입니다."),
-    SCENARIO_FORBIDDEN(HttpStatus.FORBIDDEN, "SCENAIRO_403", "해당 시나리오에 접근할 수 없습니다."),
+    SCENARIO_FORBIDDEN(HttpStatus.FORBIDDEN, "SCENARIO_403", "해당 시나리오에 접근할 수 없습니다."),
     SCENARIO_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404_1", "시나리오를 찾을 수 없습니다."),
     SCENARIO_STEP_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404_2", "대화 단계를 찾을 수 없습니다."),
     USER_AUDIO_NOT_FOUND(HttpStatus.NOT_FOUND, "SCENARIO_404_3", "저장된 음성 파일을 찾을 수 없습니다."),
@@ -24,7 +24,8 @@ public enum ScenarioErrorCode implements BaseCode {
 
     // 5xx
     SCENARIO_GENERATION_FAILED(HttpStatus.BAD_GATEWAY, "SCENAIRO_502_1", "AI 서버 시나리오 생성에 실패했습니다."),
-    SCENARIO_ANALYSIS_FAILED(HttpStatus.BAD_GATEWAY, "SCENARIO_502_2", "AI 서버 음성 분석에 실패했습니다.")
+    SCENARIO_ANALYSIS_FAILED(HttpStatus.BAD_GATEWAY, "SCENARIO_502_2", "AI 서버 음성 분석에 실패했습니다."),
+    SCENARIO_REGENERATION_FAILED(HttpStatus.BAD_GATEWAY, "SCENARIO_502_3", "AI 서버 시나리오 재생성에 실패했습니다.")
     ;
 
 

--- a/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioAnalysisResultRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioAnalysisResultRepository.java
@@ -2,11 +2,26 @@ package com.kwcapstone.server.domain.scenario.repository;
 
 import com.kwcapstone.server.domain.scenario.entity.ScenarioAnalysisResult;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.Optional;
 
 public interface ScenarioAnalysisResultRepository extends JpaRepository<ScenarioAnalysisResult, Long> {
     boolean existsByScenarioStepIdAndMemberId(Long scenarioStepId, Long memberId);
     Optional<ScenarioAnalysisResult> findTopByScenarioStepIdAndMemberIdOrderByCreatedAtDesc(Long scenarioStepId, Long memberId);
     Optional<ScenarioAnalysisResult> findByMemberIdAndClientRequestId(Long memberId, String clientRequestId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from ScenarioAnalysisResult result
+            where result.member.id = :memberId
+            and result.scenarioStep.id in :scenarioStepIds
+            """)
+    void deleteAllByMemberIdAndScenarioStepIdIn(
+            @Param("memberId") Long memberId,
+            @Param("scenarioStepIds") Collection<Long> scenarioStepIds
+    );
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioCommandService.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioCommandService.java
@@ -2,7 +2,9 @@ package com.kwcapstone.server.domain.scenario.service;
 
 import com.kwcapstone.server.domain.scenario.dto.request.ScenarioCreateReqDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioCreateResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioRegenerateResDTO;
 
 public interface ScenarioCommandService {
-    ScenarioCreateResDTO createScenario(ScenarioCreateReqDTO request);  // 시나리오 생성
+    ScenarioCreateResDTO createScenario(ScenarioCreateReqDTO request);
+    ScenarioRegenerateResDTO regenerateScenarioStep(Long scenarioId, Integer level, Integer stepNo);
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioCommandServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/service/ScenarioCommandServiceImpl.java
@@ -3,14 +3,21 @@ package com.kwcapstone.server.domain.scenario.service;
 import com.kwcapstone.server.domain.member.entity.Member;
 import com.kwcapstone.server.domain.member.repository.MemberRepository;
 import com.kwcapstone.server.domain.scenario.client.ScenarioAiClient;
+import com.kwcapstone.server.domain.scenario.client.dto.request.ScenarioGenerateAiReqDTO;
+import com.kwcapstone.server.domain.scenario.client.dto.request.ScenarioRegenerateAiReqDTO;
+import com.kwcapstone.server.domain.scenario.client.dto.response.ScenarioGenerateAiResDTO;
 import com.kwcapstone.server.domain.scenario.converter.ScenarioConverter;
 import com.kwcapstone.server.domain.scenario.dto.request.ScenarioCreateReqDTO;
-import com.kwcapstone.server.domain.scenario.client.dto.request.ScenarioGenerateAiReqDTO;
 import com.kwcapstone.server.domain.scenario.dto.response.ScenarioCreateResDTO;
-import com.kwcapstone.server.domain.scenario.client.dto.response.ScenarioGenerateAiResDTO;
+import com.kwcapstone.server.domain.scenario.dto.response.ScenarioRegenerateResDTO;
 import com.kwcapstone.server.domain.scenario.entity.Scenario;
+import com.kwcapstone.server.domain.scenario.entity.ScenarioLevel;
+import com.kwcapstone.server.domain.scenario.entity.ScenarioStep;
 import com.kwcapstone.server.domain.scenario.exception.code.ScenarioErrorCode;
+import com.kwcapstone.server.domain.scenario.repository.ScenarioAnalysisResultRepository;
+import com.kwcapstone.server.domain.scenario.repository.ScenarioLevelRepository;
 import com.kwcapstone.server.domain.scenario.repository.ScenarioRepository;
+import com.kwcapstone.server.domain.scenario.repository.ScenarioStepRepository;
 import com.kwcapstone.server.global.apiPayload.exception.CustomException;
 import com.kwcapstone.server.global.apiPayload.response.ErrorCode;
 import com.kwcapstone.server.global.security.SecurityUtil;
@@ -18,12 +25,25 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class ScenarioCommandServiceImpl implements ScenarioCommandService {
 
+    private static final int SCENARIO_LEVEL_COUNT = 3;
+    private static final int SCENARIO_STEP_COUNT = 3;
+
     private final ScenarioRepository scenarioRepository;
+    private final ScenarioLevelRepository scenarioLevelRepository;
+    private final ScenarioStepRepository scenarioStepRepository;
+    private final ScenarioAnalysisResultRepository scenarioAnalysisResultRepository;
     private final MemberRepository memberRepository;
     private final ScenarioAiClient scenarioAiClient;
 
@@ -43,12 +63,96 @@ public class ScenarioCommandServiceImpl implements ScenarioCommandService {
                 )
         );
 
-        validateAiResponse(aiResponse);
+        validateAiResponse(
+                aiResponse,
+                () -> new CustomException(ScenarioErrorCode.SCENARIO_GENERATION_FAILED)
+        );
 
         Scenario scenario = ScenarioConverter.toScenario(request, member, aiResponse);
         Scenario savedScenario = scenarioRepository.save(scenario);
 
         return ScenarioConverter.toCreateResponse(savedScenario);
+    }
+
+    @Override
+    public ScenarioRegenerateResDTO regenerateScenarioStep(
+            Long scenarioId,
+            Integer level,
+            Integer stepNo
+    ) {
+        validateLevel(level);
+        validateStep(stepNo);
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        Scenario scenario = scenarioRepository.findById(scenarioId)
+                .orElseThrow(() -> new CustomException(ScenarioErrorCode.SCENARIO_NOT_FOUND));
+
+        if (!scenario.getMember().getId().equals(memberId)) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_FORBIDDEN);
+        }
+
+        List<ScenarioLevel> scenarioLevels =
+                scenarioLevelRepository.findAllByScenarioIdOrderByLevelNoAsc(scenarioId);
+
+        Map<Integer, List<ScenarioStep>> stepsByLevelNo =
+                loadStepsByLevelNo(scenarioLevels);
+
+        validateScenarioStructure(scenarioLevels, stepsByLevelNo);
+
+        ScenarioGenerateAiResDTO aiResponse =
+                scenarioAiClient.regenerateScenarioStep(
+                        buildRegenerateAiRequest(
+                                scenario,
+                                scenarioLevels,
+                                stepsByLevelNo,
+                                level,
+                                stepNo
+                        )
+                );
+
+        validateAiResponse(
+                aiResponse,
+                () -> new CustomException(ScenarioErrorCode.SCENARIO_REGENERATION_FAILED)
+        );
+
+        applyRegeneratedContent(
+                scenarioLevels,
+                stepsByLevelNo,
+                aiResponse,
+                level,
+                stepNo
+        );
+
+        List<Long> affectedStepIds =
+                collectAffectedStepIds(stepsByLevelNo, level, stepNo);
+
+        if (!affectedStepIds.isEmpty()) {
+            scenarioAnalysisResultRepository.deleteAllByMemberIdAndScenarioStepIdIn(
+                    memberId,
+                    affectedStepIds
+            );
+        }
+
+        ScenarioLevel currentLevel = scenarioLevels.get(level - 1);
+        ScenarioStep currentStep = stepsByLevelNo.get(level).get(stepNo - 1);
+
+        return new ScenarioRegenerateResDTO(
+                scenario.getId(),
+                scenario.getTitle(),
+                scenario.getDescription(),
+                new ScenarioRegenerateResDTO.RegeneratedFrom(level, stepNo),
+                new ScenarioRegenerateResDTO.CurrentStep(
+                        scenario.getId(),
+                        level,
+                        stepNo,
+                        currentLevel.getLevelTitle(),
+                        currentStep.getStepName(),
+                        currentStep.getAssistantMessage(),
+                        currentStep.getUserIntent(),
+                        false
+                )
+        );
     }
 
     private void validateCreateRequest(ScenarioCreateReqDTO request) {
@@ -61,24 +165,176 @@ public class ScenarioCommandServiceImpl implements ScenarioCommandService {
         }
     }
 
-    private void validateAiResponse(ScenarioGenerateAiResDTO aiResponse) {
+    private void validateLevel(Integer level) {
+        if (level == null || level < 1 || level > SCENARIO_LEVEL_COUNT) {
+            throw new CustomException(ScenarioErrorCode.INVALID_LEVEL);
+        }
+    }
+
+    private void validateStep(Integer stepNo) {
+        if (stepNo == null || stepNo < 1 || stepNo > SCENARIO_STEP_COUNT) {
+            throw new CustomException(ScenarioErrorCode.INVALID_STEP);
+        }
+    }
+
+    private Map<Integer, List<ScenarioStep>> loadStepsByLevelNo(
+            List<ScenarioLevel> scenarioLevels
+    ) {
+        return scenarioLevels.stream()
+                .collect(Collectors.toMap(
+                        ScenarioLevel::getLevelNo,
+                        scenarioLevel -> scenarioStepRepository
+                                .findAllByScenarioLevelIdOrderByStepNoAsc(scenarioLevel.getId())
+                ));
+    }
+
+    private void validateScenarioStructure(
+            List<ScenarioLevel> scenarioLevels,
+            Map<Integer, List<ScenarioStep>> stepsByLevelNo
+    ) {
+        if (scenarioLevels.size() != SCENARIO_LEVEL_COUNT) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_STEP_NOT_FOUND);
+        }
+
+        boolean hasInvalidStepCount = scenarioLevels.stream()
+                .anyMatch(scenarioLevel -> stepsByLevelNo
+                        .getOrDefault(scenarioLevel.getLevelNo(), List.of())
+                        .size() != SCENARIO_STEP_COUNT);
+
+        if (hasInvalidStepCount) {
+            throw new CustomException(ScenarioErrorCode.SCENARIO_STEP_NOT_FOUND);
+        }
+    }
+
+    private ScenarioRegenerateAiReqDTO buildRegenerateAiRequest(
+            Scenario scenario,
+            List<ScenarioLevel> scenarioLevels,
+            Map<Integer, List<ScenarioStep>> stepsByLevelNo,
+            Integer level,
+            Integer stepNo
+    ) {
+        List<ScenarioRegenerateAiReqDTO.Level> levels = scenarioLevels.stream()
+                .sorted(Comparator.comparing(ScenarioLevel::getLevelNo))
+                .map(scenarioLevel -> new ScenarioRegenerateAiReqDTO.Level(
+                        scenarioLevel.getLevelTitle(),
+                        scenarioLevel.getLevelDescription(),
+                        stepsByLevelNo.get(scenarioLevel.getLevelNo()).stream()
+                                .sorted(Comparator.comparing(ScenarioStep::getStepNo))
+                                .map(scenarioStep -> new ScenarioRegenerateAiReqDTO.Step(
+                                        scenarioStep.getStepName(),
+                                        scenarioStep.getAssistantMessage(),
+                                        scenarioStep.getUserIntent()
+                                ))
+                                .toList()
+                ))
+                .toList();
+
+        return new ScenarioRegenerateAiReqDTO(
+                scenario.getScenarioContext(),
+                scenario.getGoal(),
+                levels,
+                level - 1,
+                stepNo - 1
+        );
+    }
+
+    private void validateAiResponse(
+            ScenarioGenerateAiResDTO aiResponse,
+            Supplier<CustomException> exceptionSupplier
+    ) {
         if (aiResponse == null || !Boolean.TRUE.equals(aiResponse.getSuccess())) {
-            throw new CustomException(ScenarioErrorCode.SCENARIO_GENERATION_FAILED);
+            throw exceptionSupplier.get();
         }
 
         if (aiResponse.getData() == null || aiResponse.getData().getLevels() == null) {
-            throw new CustomException(ScenarioErrorCode.SCENARIO_GENERATION_FAILED);
+            throw exceptionSupplier.get();
         }
 
-        if (aiResponse.getData().getLevels().size() != 3) {
-            throw new CustomException(ScenarioErrorCode.SCENARIO_GENERATION_FAILED);
+        if (aiResponse.getData().getLevels().size() != SCENARIO_LEVEL_COUNT) {
+            throw exceptionSupplier.get();
         }
 
         boolean hasInvalidStepCount = aiResponse.getData().getLevels().stream()
-                .anyMatch(level -> level.getSteps() == null || level.getSteps().size() != 3);
+                .anyMatch(level -> level.getSteps() == null
+                        || level.getSteps().size() != SCENARIO_STEP_COUNT);
 
         if (hasInvalidStepCount) {
-            throw new CustomException(ScenarioErrorCode.SCENARIO_GENERATION_FAILED);
+            throw exceptionSupplier.get();
         }
+    }
+
+    private void applyRegeneratedContent(
+            List<ScenarioLevel> scenarioLevels,
+            Map<Integer, List<ScenarioStep>> stepsByLevelNo,
+            ScenarioGenerateAiResDTO aiResponse,
+            Integer targetLevel,
+            Integer targetStepNo
+    ) {
+        List<ScenarioGenerateAiResDTO.Level> aiLevels =
+                aiResponse.getData().getLevels();
+
+        for (int levelIndex = 0; levelIndex < scenarioLevels.size(); levelIndex++) {
+            ScenarioLevel scenarioLevel = scenarioLevels.get(levelIndex);
+            ScenarioGenerateAiResDTO.Level aiLevel = aiLevels.get(levelIndex);
+
+            if (scenarioLevel.getLevelNo() > targetLevel) {
+                scenarioLevel.updateContent(
+                        aiLevel.getLevelTitle(),
+                        aiLevel.getLevelDescription()
+                );
+            }
+
+            List<ScenarioStep> scenarioSteps =
+                    stepsByLevelNo.get(scenarioLevel.getLevelNo());
+            List<ScenarioGenerateAiResDTO.Step> aiSteps = aiLevel.getSteps();
+
+            for (int stepIndex = 0; stepIndex < scenarioSteps.size(); stepIndex++) {
+                ScenarioStep scenarioStep = scenarioSteps.get(stepIndex);
+
+                if (isAffectedStep(
+                        scenarioLevel.getLevelNo(),
+                        scenarioStep.getStepNo(),
+                        targetLevel,
+                        targetStepNo
+                )) {
+                    ScenarioGenerateAiResDTO.Step aiStep = aiSteps.get(stepIndex);
+                    scenarioStep.updateContent(
+                            aiStep.getStep(),
+                            aiStep.getAssistantMessage(),
+                            aiStep.getUserIntent()
+                    );
+                }
+            }
+        }
+    }
+
+    private List<Long> collectAffectedStepIds(
+            Map<Integer, List<ScenarioStep>> stepsByLevelNo,
+            Integer targetLevel,
+            Integer targetStepNo
+    ) {
+        List<Long> affectedStepIds = new ArrayList<>();
+
+        stepsByLevelNo.forEach((levelNo, steps) -> steps.stream()
+                .filter(step -> isAffectedStep(
+                        levelNo,
+                        step.getStepNo(),
+                        targetLevel,
+                        targetStepNo
+                ))
+                .map(ScenarioStep::getId)
+                .forEach(affectedStepIds::add));
+
+        return affectedStepIds;
+    }
+
+    private boolean isAffectedStep(
+            Integer levelNo,
+            Integer stepNo,
+            Integer targetLevel,
+            Integer targetStepNo
+    ) {
+        return levelNo > targetLevel
+                || levelNo.equals(targetLevel) && stepNo >= targetStepNo;
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #38

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

시나리오 특정 단계 재생성 API를 구현했습니다.

### 구현 내용
- 시나리오 단계 재생성 API 구현
- AI 서버 `/regenerate-scenario-step` 연동
- 재생성 대상 구간 DB 업데이트 처리
- 기존 답변/분석 결과 초기화 처리

### 세부 사항
- 로그인 사용자 기준 시나리오 접근 권한 검증
- `level`, `stepNo` 유효성 검증 추가
  - `level`: 1~3
  - `stepNo`: 1~3
- 기존 시나리오 전체 구조 조회
- Spring API 기준 1-based 값을 AI 서버 기준 0-based index로 변환
  - `targetLevelIndex = level - 1`
  - `targetStepIndex = stepNo - 1`
- AI 서버 요청 DTO 구성
  - `scenarioContext`
  - `goal`
  - `levels`
  - `targetLevelIndex`
  - `targetStepIndex`
- AI 서버 응답 중 재생성 대상 구간만 DB 반영
- 재생성 구간의 기존 답변/분석 결과 삭제 또는 초기화 처리
- 재생성 시작 단계 정보를 `currentStep`으로 반환
- Swagger API 문서 작성
- 공통 응답 형식 적용

### API 목록
| Method | URL | 설명 |
|------|------|------|
| POST | `/api/conversations/scenarios/{scenarioId}/levels/{level}/steps/{stepNo}/regenerate` | 시나리오 단계 재생성 |

## 🧪 테스트 결과
> Apidog 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

https://www.notion.so/API-36b3f5a4dd448021b6e6f742dabaae11?source=copy_link

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.
- 재생성은 요청한 단계 이후 구간만 반영하도록 구현했습니다.
- 기존 시나리오 전체를 덮어쓰지 않고 부분 업데이트 방식으로 처리했습니다.
- AI 서버 기준 index는 0-based, Spring API 기준 값은 1-based로 처리했습니다.