### PR TITLE
[Feat] 레포트 API 구현

### DIFF
--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/repository/BasicPronunciationPracticeRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/repository/BasicPronunciationPracticeRepository.java
@@ -25,4 +25,6 @@ public interface BasicPronunciationPracticeRepository extends JpaRepository<Basi
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end
     );
+
+    long countByMemberIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(Long memberId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/repository/BasicPronunciationPracticeRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/repository/BasicPronunciationPracticeRepository.java
@@ -3,10 +3,26 @@ package com.kwcapstone.server.domain.basicpronunciation.repository;
 import com.kwcapstone.server.domain.basicpronunciation.entity.BasicPronunciationPractice;
 import com.kwcapstone.server.domain.basicpronunciation.enums.BasicVowel;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface BasicPronunciationPracticeRepository extends JpaRepository<BasicPronunciationPractice, Long> {
     Optional<BasicPronunciationPractice> findByMemberIdAndClientRequestId(Long memberId, String clientRequestId);
     Optional<BasicPronunciationPractice> findTopByMemberIdAndTargetVowelOrderByCreatedAtDesc(Long memberId, BasicVowel targetVowel);
+
+    @Query("""
+        select avg(p.accuracyScore)
+        from BasicPronunciationPractice p
+        where p.member.id = :memberId
+            and p.createdAt >= :start
+            and p.createdAt < :end
+    """)
+    Double findAverageAccuracyScore(
+            @Param("memberId") Long memberId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 }

--- a/src/main/java/com/kwcapstone/server/domain/basicpronunciation/repository/BasicPronunciationPracticeRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/basicpronunciation/repository/BasicPronunciationPracticeRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -27,4 +28,17 @@ public interface BasicPronunciationPracticeRepository extends JpaRepository<Basi
     );
 
     long countByMemberIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(Long memberId, LocalDateTime start, LocalDateTime end);
+
+    @Query("""
+        select coalesce(sum(p.accuracyScore), 0)
+        from BasicPronunciationPractice p
+        where p.member.id = :memberId
+            and p.createdAt >= :start
+            and p.createdAt < :end
+    """)
+    BigDecimal sumAccuracyScore(
+            @Param("memberId") Long memberId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/repository/MySentenceAnalysisResultRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/repository/MySentenceAnalysisResultRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -26,4 +27,17 @@ public interface MySentenceAnalysisResultRepository extends JpaRepository<MySent
     );
 
     long countByMemberIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(Long memberId, LocalDateTime start, LocalDateTime end);
+
+    @Query("""
+        select coalesce(sum(r.pronunciationScore), 0)
+        from MySentenceAnalysisResult r
+        where r.member.id = :memberId
+            and r.createdAt >= :start
+            and r.createdAt < :end
+    """)
+    BigDecimal sumPronunciationScore(
+            @Param("memberId") Long memberId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/repository/MySentenceAnalysisResultRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/repository/MySentenceAnalysisResultRepository.java
@@ -24,4 +24,6 @@ public interface MySentenceAnalysisResultRepository extends JpaRepository<MySent
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end
     );
+
+    long countByMemberIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(Long memberId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/kwcapstone/server/domain/mysentence/repository/MySentenceAnalysisResultRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/mysentence/repository/MySentenceAnalysisResultRepository.java
@@ -2,10 +2,26 @@ package com.kwcapstone.server.domain.mysentence.repository;
 
 import com.kwcapstone.server.domain.mysentence.entity.MySentenceAnalysisResult;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface MySentenceAnalysisResultRepository extends JpaRepository<MySentenceAnalysisResult, Long> {
     Optional<MySentenceAnalysisResult> findTopByMySentenceIdAndMemberIdOrderByCreatedAtDesc(Long mySentenceId, Long memberId);
     Optional<MySentenceAnalysisResult> findByMemberIdAndClientRequestId(Long memberId, String clientRequestId);
+
+    @Query("""
+        select avg(r.pronunciationScore)
+        from MySentenceAnalysisResult r
+        where r.member.id = :memberId
+            and r.createdAt >= :start
+            and r.createdAt < :end
+    """)
+    Double findAveragePronunciationScore(
+            @Param("memberId") Long memberId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 }

--- a/src/main/java/com/kwcapstone/server/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kwcapstone/server/domain/report/controller/ReportController.java
@@ -1,0 +1,31 @@
+package com.kwcapstone.server.domain.report.controller;
+
+import com.kwcapstone.server.domain.report.dto.response.PronunciationAccuracyReportResDTO;
+import com.kwcapstone.server.domain.report.service.ReportService;
+import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
+import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reports")
+public class ReportController {
+    private final ReportService reportService;
+
+    @Operation(summary = "주/월 평균 발음 정확도 조회")
+    @GetMapping("/pronunciation-accuracy")
+    public ApiResponse<PronunciationAccuracyReportResDTO> getPronunciationAccuracy(
+            @RequestParam String period,
+            @RequestParam String type,
+            @RequestParam(required = false) String baseDate
+    ) {
+        PronunciationAccuracyReportResDTO result = reportService.getPronunciationAccuracy(period, type, baseDate);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kwcapstone/server/domain/report/controller/ReportController.java
@@ -1,6 +1,7 @@
 package com.kwcapstone.server.domain.report.controller;
 
 import com.kwcapstone.server.domain.report.dto.response.PronunciationAccuracyReportResDTO;
+import com.kwcapstone.server.domain.report.dto.response.WeeklyStampsReportResDTO;
 import com.kwcapstone.server.domain.report.service.ReportService;
 import com.kwcapstone.server.global.apiPayload.response.ApiResponse;
 import com.kwcapstone.server.global.apiPayload.response.SuccessCode;
@@ -25,6 +26,16 @@ public class ReportController {
             @RequestParam(required = false) String baseDate
     ) {
         PronunciationAccuracyReportResDTO result = reportService.getPronunciationAccuracy(period, type, baseDate);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    @Operation(summary = "위클리 스탬프 조회")
+    @GetMapping("/weekly-stamps")
+    public ApiResponse<WeeklyStampsReportResDTO> getWeeklyStamps(
+            @RequestParam(required = false) String baseDate
+    ) {
+        WeeklyStampsReportResDTO result = reportService.getWeeklyStamps(baseDate);
 
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }

--- a/src/main/java/com/kwcapstone/server/domain/report/controller/ReportController.java
+++ b/src/main/java/com/kwcapstone/server/domain/report/controller/ReportController.java
@@ -1,5 +1,6 @@
 package com.kwcapstone.server.domain.report.controller;
 
+import com.kwcapstone.server.domain.report.dto.response.AchievementTrendReportResDTO;
 import com.kwcapstone.server.domain.report.dto.response.PronunciationAccuracyReportResDTO;
 import com.kwcapstone.server.domain.report.dto.response.WeeklyStampsReportResDTO;
 import com.kwcapstone.server.domain.report.service.ReportService;
@@ -36,6 +37,17 @@ public class ReportController {
             @RequestParam(required = false) String baseDate
     ) {
         WeeklyStampsReportResDTO result = reportService.getWeeklyStamps(baseDate);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    @Operation(summary = "학습 성취도 추이 조회")
+    @GetMapping("/achievement-trend")
+    public ApiResponse<AchievementTrendReportResDTO> getAchievementTrend(
+            @RequestParam String period,
+            @RequestParam(required = false) String baseDate
+    ) {
+        AchievementTrendReportResDTO result = reportService.getAchievementTrend(period, baseDate);
 
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }

--- a/src/main/java/com/kwcapstone/server/domain/report/dto/response/AchievementTrendReportResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/report/dto/response/AchievementTrendReportResDTO.java
@@ -1,0 +1,34 @@
+package com.kwcapstone.server.domain.report.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AchievementTrendReportResDTO {
+    private String period;
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    private List<Point> points;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Point {
+        private String label;
+
+        private LocalDate startDate;
+        private LocalDate endDate;
+
+        private BigDecimal pronunciationAccuracy;
+        private BigDecimal meaningDeliveryRate;
+
+        private Boolean hasPronunciationData;
+        private Boolean hasMeaningDeliveryData;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/report/dto/response/PronunciationAccuracyReportResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/report/dto/response/PronunciationAccuracyReportResDTO.java
@@ -1,0 +1,35 @@
+package com.kwcapstone.server.domain.report.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class PronunciationAccuracyReportResDTO {
+    private String period;
+    private String type;
+    private String typeLabel;
+
+    private BigDecimal currentAverage;
+    private BigDecimal previousAverage;
+    private BigDecimal diff;
+
+    private String currentLabel;
+    private String previousLabel;
+
+    private Boolean hasCurrentData;
+    private Boolean hasPreviousData;
+
+    private Range currentRange;
+    private Range previousRange;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Range {
+        private LocalDate startDate;
+        private LocalDate endDate;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/report/dto/response/WeeklyStampsReportResDTO.java
+++ b/src/main/java/com/kwcapstone/server/domain/report/dto/response/WeeklyStampsReportResDTO.java
@@ -1,0 +1,32 @@
+package com.kwcapstone.server.domain.report.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class WeeklyStampsReportResDTO {
+    private LocalDate weekStartDate;
+    private LocalDate weekEndDate;
+
+    private Long totalStudyDays;
+    private Long totalStydyCount;
+
+    private List<Stamp> stamps;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Stamp {
+        private LocalDate date;
+        private String dayOfWeek;
+        private String dayLabel;
+
+        private Boolean hasStudy;
+        private Long studyCount;
+
+        private List<String> completedTypes;
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/report/enums/ReportPeriod.java
+++ b/src/main/java/com/kwcapstone/server/domain/report/enums/ReportPeriod.java
@@ -1,0 +1,31 @@
+package com.kwcapstone.server.domain.report.enums;
+
+import com.kwcapstone.server.global.apiPayload.exception.CustomException;
+import com.kwcapstone.server.global.apiPayload.response.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum ReportPeriod {
+    WEEK("이번 주", "저번 주"),
+    MONTH("이번 달", "저번 달")
+    ;
+
+    private final String currentLabel;
+    private final String previousLabel;
+
+    // 문자열 -> enum 변환
+    public static ReportPeriod from(String value) {
+        if (value == null || value.isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        return Arrays.stream(values())
+                .filter(period -> period.name().equalsIgnoreCase(value.trim()))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REQUEST));
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/report/enums/ReportPracticeType.java
+++ b/src/main/java/com/kwcapstone/server/domain/report/enums/ReportPracticeType.java
@@ -1,0 +1,31 @@
+package com.kwcapstone.server.domain.report.enums;
+
+import com.kwcapstone.server.global.apiPayload.exception.CustomException;
+import com.kwcapstone.server.global.apiPayload.response.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum ReportPracticeType {
+    MY_SENTENCE("문장 노트"),
+    BASIC("기초 발성"),
+    SCENARIO("시나리오")
+    ;
+
+    private final String typeLabel;
+
+    // 문자열 -> enum 변환
+    public static ReportPracticeType from(String value) {
+        if (value == null || value.isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        return Arrays.stream(values())
+                .filter(type -> type.name().equalsIgnoreCase(value.trim()))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REQUEST));
+    }
+}

--- a/src/main/java/com/kwcapstone/server/domain/report/service/ReportService.java
+++ b/src/main/java/com/kwcapstone/server/domain/report/service/ReportService.java
@@ -1,0 +1,7 @@
+package com.kwcapstone.server.domain.report.service;
+
+import com.kwcapstone.server.domain.report.dto.response.PronunciationAccuracyReportResDTO;
+
+public interface ReportService {
+    PronunciationAccuracyReportResDTO getPronunciationAccuracy(String period, String type, String baseDate);
+}

--- a/src/main/java/com/kwcapstone/server/domain/report/service/ReportService.java
+++ b/src/main/java/com/kwcapstone/server/domain/report/service/ReportService.java
@@ -1,7 +1,9 @@
 package com.kwcapstone.server.domain.report.service;
 
 import com.kwcapstone.server.domain.report.dto.response.PronunciationAccuracyReportResDTO;
+import com.kwcapstone.server.domain.report.dto.response.WeeklyStampsReportResDTO;
 
 public interface ReportService {
     PronunciationAccuracyReportResDTO getPronunciationAccuracy(String period, String type, String baseDate);
+    WeeklyStampsReportResDTO getWeeklyStamps(String baseDate);
 }

--- a/src/main/java/com/kwcapstone/server/domain/report/service/ReportService.java
+++ b/src/main/java/com/kwcapstone/server/domain/report/service/ReportService.java
@@ -1,9 +1,11 @@
 package com.kwcapstone.server.domain.report.service;
 
+import com.kwcapstone.server.domain.report.dto.response.AchievementTrendReportResDTO;
 import com.kwcapstone.server.domain.report.dto.response.PronunciationAccuracyReportResDTO;
 import com.kwcapstone.server.domain.report.dto.response.WeeklyStampsReportResDTO;
 
 public interface ReportService {
     PronunciationAccuracyReportResDTO getPronunciationAccuracy(String period, String type, String baseDate);
     WeeklyStampsReportResDTO getWeeklyStamps(String baseDate);
+    AchievementTrendReportResDTO getAchievementTrend(String period, String baseDate);
 }

--- a/src/main/java/com/kwcapstone/server/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/report/service/ReportServiceImpl.java
@@ -3,6 +3,7 @@ package com.kwcapstone.server.domain.report.service;
 import com.kwcapstone.server.domain.basicpronunciation.repository.BasicPronunciationPracticeRepository;
 import com.kwcapstone.server.domain.mysentence.repository.MySentenceAnalysisResultRepository;
 import com.kwcapstone.server.domain.report.dto.response.PronunciationAccuracyReportResDTO;
+import com.kwcapstone.server.domain.report.dto.response.WeeklyStampsReportResDTO;
 import com.kwcapstone.server.domain.report.enums.ReportPeriod;
 import com.kwcapstone.server.domain.report.enums.ReportPracticeType;
 import com.kwcapstone.server.domain.scenario.repository.ScenarioAnalysisResultRepository;
@@ -20,6 +21,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -57,6 +60,90 @@ public class ReportServiceImpl implements ReportService {
                 previousAverage != null,
                 toResponseRange(currentRange),
                 toResponseRange(previousRange)
+        );
+    }
+
+    @Override
+    public WeeklyStampsReportResDTO getWeeklyStamps(String baseDate) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        LocalDate referenceDate = parseBaseDate(baseDate);
+        LocalDate weekStartDate = referenceDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate weekEndDate = weekStartDate.plusDays(6);
+
+        List<WeeklyStampsReportResDTO.Stamp> stamps = new ArrayList<>();
+
+        long totalStudyDays = 0L;
+        long totalStudyCount = 0L;
+
+        for (int i = 0; i < 7; i++) {
+            LocalDate date = weekStartDate.plusDays(i);
+
+            LocalDateTime start = date.atStartOfDay();
+            LocalDateTime end = date.plusDays(1).atStartOfDay();
+
+            long basicCount = basicPronunciationPracticeRepository
+                    .countByMemberIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+                            memberId,
+                            start,
+                            end
+                    );
+
+            long mySentenceCount = mySentenceAnalysisResultRepository
+                    .countByMemberIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+                            memberId,
+                            start,
+                            end
+                    );
+
+            long scenarioCount = scenarioAnalysisResultRepository
+                    .countByMemberIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+                            memberId,
+                            start,
+                            end
+                    );
+
+            long studyCount = basicCount + mySentenceCount + scenarioCount;
+            boolean hasStudy = studyCount > 0;
+
+            if (hasStudy) {
+                totalStudyDays++;
+            }
+
+            totalStudyCount += studyCount;
+
+            List<String> completedTypes = new ArrayList<>();
+
+            if (basicCount > 0) {
+                completedTypes.add(ReportPracticeType.BASIC.name());
+            }
+
+            if (mySentenceCount > 0) {
+                completedTypes.add(ReportPracticeType.MY_SENTENCE.name());
+            }
+
+            if (scenarioCount > 0) {
+                completedTypes.add(ReportPracticeType.SCENARIO.name());
+            }
+
+            stamps.add(
+                    new WeeklyStampsReportResDTO.Stamp(
+                            date,
+                            date.getDayOfWeek().name(),
+                            toDayLabel(date.getDayOfWeek()),
+                            hasStudy,
+                            studyCount,
+                            completedTypes
+                    )
+            );
+        }
+
+        return new WeeklyStampsReportResDTO(
+                weekStartDate,
+                weekEndDate,
+                totalStudyDays,
+                totalStudyCount,
+                stamps
         );
     }
 
@@ -142,6 +229,18 @@ public class ReportServiceImpl implements ReportService {
                 range.startDate(),
                 range.endExclusiveDate().minusDays(1)
         );
+    }
+
+    private String toDayLabel(DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> "월";
+            case TUESDAY -> "화";
+            case WEDNESDAY -> "수";
+            case THURSDAY -> "목";
+            case FRIDAY -> "금";
+            case SATURDAY -> "토";
+            case SUNDAY -> "일";
+        };
     }
 
     private record DateRange(

--- a/src/main/java/com/kwcapstone/server/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/report/service/ReportServiceImpl.java
@@ -1,0 +1,151 @@
+package com.kwcapstone.server.domain.report.service;
+
+import com.kwcapstone.server.domain.basicpronunciation.repository.BasicPronunciationPracticeRepository;
+import com.kwcapstone.server.domain.mysentence.repository.MySentenceAnalysisResultRepository;
+import com.kwcapstone.server.domain.report.dto.response.PronunciationAccuracyReportResDTO;
+import com.kwcapstone.server.domain.report.enums.ReportPeriod;
+import com.kwcapstone.server.domain.report.enums.ReportPracticeType;
+import com.kwcapstone.server.domain.scenario.repository.ScenarioAnalysisResultRepository;
+import com.kwcapstone.server.global.apiPayload.exception.CustomException;
+import com.kwcapstone.server.global.apiPayload.response.ErrorCode;
+import com.kwcapstone.server.global.security.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAdjusters;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportServiceImpl implements ReportService {
+    private final MySentenceAnalysisResultRepository mySentenceAnalysisResultRepository;
+    private final BasicPronunciationPracticeRepository basicPronunciationPracticeRepository;
+    private final ScenarioAnalysisResultRepository scenarioAnalysisResultRepository;
+
+    @Override
+    public PronunciationAccuracyReportResDTO getPronunciationAccuracy(String period, String type, String baseDate) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        ReportPeriod reportPeriod = ReportPeriod.from(period);
+        ReportPracticeType practiceType = ReportPracticeType.from(type);
+        LocalDate referenceDate = parseBaseDate(baseDate);
+
+        DateRange currentRange = calculateCurrentRange(reportPeriod, referenceDate);
+        DateRange previousRange = calculatePreviousRange(reportPeriod, currentRange);
+
+        BigDecimal currentAverage = findAverage(memberId, practiceType, currentRange);
+        BigDecimal previousAverage = findAverage(memberId, practiceType, previousRange);
+        BigDecimal diff = calculateDiff(currentAverage, previousAverage);
+
+        return new PronunciationAccuracyReportResDTO(
+                reportPeriod.name(),
+                practiceType.name(),
+                practiceType.getTypeLabel(),
+                currentAverage,
+                previousAverage,
+                diff,
+                reportPeriod.getCurrentLabel(),
+                reportPeriod.getPreviousLabel(),
+                currentAverage != null,
+                previousAverage != null,
+                toResponseRange(currentRange),
+                toResponseRange(previousRange)
+        );
+    }
+
+    private LocalDate parseBaseDate(String baseDate) {
+        if (baseDate == null || baseDate.isBlank()) {
+            return LocalDate.now();
+        }
+
+        try {
+            return LocalDate.parse(baseDate.trim());
+        } catch (DateTimeParseException e) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    private DateRange calculateCurrentRange(ReportPeriod period, LocalDate baseDate) {
+        if (period == ReportPeriod.WEEK) {
+            LocalDate startDate = baseDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+            LocalDate endExclusiveDate = startDate.plusWeeks(1);
+
+            return new DateRange(startDate, endExclusiveDate);
+        }
+
+        LocalDate startDate = baseDate.withDayOfMonth(1);
+        LocalDate endExclusiveDate = startDate.plusMonths(1);
+
+        return new DateRange(startDate, endExclusiveDate);
+    }
+
+    private DateRange calculatePreviousRange(ReportPeriod period, DateRange currentRange) {
+        if (period == ReportPeriod.WEEK) {
+            return new DateRange(
+                    currentRange.startDate().minusWeeks(1),
+                    currentRange.startDate()
+            );
+        }
+
+        return new DateRange(
+                currentRange.startDate().minusMonths(1),
+                currentRange.startDate()
+        );
+    }
+
+    private BigDecimal findAverage(Long memberId, ReportPracticeType type, DateRange range) {
+        LocalDateTime start = range.startDate().atStartOfDay();
+        LocalDateTime end = range.endExclusiveDate().atStartOfDay();
+
+        Double average = switch (type) {
+            case MY_SENTENCE -> mySentenceAnalysisResultRepository.findAveragePronunciationScore(
+                    memberId,
+                    start,
+                    end
+            );
+            case BASIC -> basicPronunciationPracticeRepository.findAverageAccuracyScore(
+                    memberId,
+                    start,
+                    end
+            );
+            case SCENARIO -> scenarioAnalysisResultRepository.findAveragePronunciationScore(
+                    memberId,
+                    start,
+                    end
+            );
+        };
+
+        if (average == null) {
+            return null;
+        }
+
+        return BigDecimal.valueOf(average).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal calculateDiff(BigDecimal currentAverage, BigDecimal previousAverage) {
+        if (currentAverage == null || previousAverage == null) {
+            return null;
+        }
+
+        return currentAverage.subtract(previousAverage).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private PronunciationAccuracyReportResDTO.Range toResponseRange(DateRange range) {
+        return new PronunciationAccuracyReportResDTO.Range(
+                range.startDate(),
+                range.endExclusiveDate().minusDays(1)
+        );
+    }
+
+    private record DateRange(
+            LocalDate startDate,
+            LocalDate endExclusiveDate
+    ) {}
+}

--- a/src/main/java/com/kwcapstone/server/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/com/kwcapstone/server/domain/report/service/ReportServiceImpl.java
@@ -2,6 +2,7 @@ package com.kwcapstone.server.domain.report.service;
 
 import com.kwcapstone.server.domain.basicpronunciation.repository.BasicPronunciationPracticeRepository;
 import com.kwcapstone.server.domain.mysentence.repository.MySentenceAnalysisResultRepository;
+import com.kwcapstone.server.domain.report.dto.response.AchievementTrendReportResDTO;
 import com.kwcapstone.server.domain.report.dto.response.PronunciationAccuracyReportResDTO;
 import com.kwcapstone.server.domain.report.dto.response.WeeklyStampsReportResDTO;
 import com.kwcapstone.server.domain.report.enums.ReportPeriod;
@@ -147,6 +148,185 @@ public class ReportServiceImpl implements ReportService {
         );
     }
 
+    @Override
+    public AchievementTrendReportResDTO getAchievementTrend(String period, String baseDate) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        ReportPeriod reportPeriod = ReportPeriod.from(period);
+        LocalDate referenceDate = parseBaseDate(baseDate);
+
+        List<DateRangeWithLabel> ranges = calculateTrendRanges(reportPeriod, referenceDate);
+        List<AchievementTrendReportResDTO.Point> points = new ArrayList<>();
+
+        for (DateRangeWithLabel range : ranges) {
+            BigDecimal pronunciationAccuracy = calculateTotalPronunciationAverage(
+                    memberId,
+                    range.dateRange()
+            );
+
+            BigDecimal meaningDeliveryRate = findAverageMeaningDeliveryScore(
+                    memberId,
+                    range.dateRange()
+            );
+
+            points.add(
+                    new AchievementTrendReportResDTO.Point(
+                            range.label(),
+                            range.dateRange().startDate(),
+                            range.dateRange().endExclusiveDate().minusDays(1),
+                            pronunciationAccuracy,
+                            meaningDeliveryRate,
+                            pronunciationAccuracy != null,
+                            meaningDeliveryRate != null
+                    )
+            );
+        }
+
+        LocalDate startDate = ranges.get(0).dateRange().startDate();
+        LocalDate endDate = ranges.get(ranges.size() - 1)
+                .dateRange()
+                .endExclusiveDate()
+                .minusDays(1);
+
+        return new AchievementTrendReportResDTO(
+                reportPeriod.name(),
+                startDate,
+                endDate,
+                points
+        );
+    }
+
+    private List<DateRangeWithLabel> calculateTrendRanges(ReportPeriod period, LocalDate baseDate) {
+        if (period == ReportPeriod.WEEK) {
+            return calculateWeeklyTrendRanges(baseDate);
+        }
+
+        return calculateMonthlyTrendRanges(baseDate);
+    }
+
+    private List<DateRangeWithLabel> calculateWeeklyTrendRanges(LocalDate baseDate) {
+        LocalDate weekStartDate = baseDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+
+        List<DateRangeWithLabel> ranges = new ArrayList<>();
+
+        for (int i = 0; i < 7; i++) {
+            LocalDate date = weekStartDate.plusDays(i);
+
+            ranges.add(
+                    new DateRangeWithLabel(
+                            toDayLabel(date.getDayOfWeek()),
+                            new DateRange(date, date.plusDays(1))
+                    )
+            );
+        }
+
+        return ranges;
+    }
+
+    private List<DateRangeWithLabel> calculateMonthlyTrendRanges(LocalDate baseDate) {
+        LocalDate monthStartDate = baseDate.withDayOfMonth(1);
+        LocalDate nextMonthStartDate = monthStartDate.plusMonths(1);
+
+        List<DateRangeWithLabel> ranges = new ArrayList<>();
+
+        for (int i = 0; i < 4; i++) {
+            LocalDate startDate = monthStartDate.plusDays(i * 7L);
+            LocalDate endExclusiveDate;
+
+            if (i == 3) {
+                endExclusiveDate = nextMonthStartDate;
+            } else {
+                endExclusiveDate = startDate.plusDays(7);
+            }
+
+            ranges.add(
+                    new DateRangeWithLabel(
+                            (i + 1) + "주차",
+                            new DateRange(startDate, endExclusiveDate)
+                    )
+            );
+        }
+
+        return ranges;
+    }
+
+    private BigDecimal calculateTotalPronunciationAverage(Long memberId, DateRange range) {
+        LocalDateTime start = range.startDate().atStartOfDay();
+        LocalDateTime end = range.endExclusiveDate().atStartOfDay();
+
+        BigDecimal basicSum = basicPronunciationPracticeRepository.sumAccuracyScore(
+                memberId,
+                start,
+                end
+        );
+
+        BigDecimal mySentenceSum = mySentenceAnalysisResultRepository.sumPronunciationScore(
+                memberId,
+                start,
+                end
+        );
+
+        BigDecimal scenarioSum = scenarioAnalysisResultRepository.sumPronunciationScore(
+                memberId,
+                start,
+                end
+        );
+
+        long basicCount = basicPronunciationPracticeRepository
+                .countByMemberIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+                        memberId,
+                        start,
+                        end
+                );
+
+        long mySentenceCount = mySentenceAnalysisResultRepository
+                .countByMemberIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+                        memberId,
+                        start,
+                        end
+                );
+
+        long scenarioCount = scenarioAnalysisResultRepository
+                .countByMemberIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+                        memberId,
+                        start,
+                        end
+                );
+
+        long totalCount = basicCount + mySentenceCount + scenarioCount;
+
+        if (totalCount == 0) {
+            return null;
+        }
+
+        BigDecimal totalSum = nullToZero(basicSum)
+                .add(nullToZero(mySentenceSum))
+                .add(nullToZero(scenarioSum));
+
+        return totalSum.divide(
+                BigDecimal.valueOf(totalCount),
+                2,
+                RoundingMode.HALF_UP
+        );
+    }
+
+    private BigDecimal findAverageMeaningDeliveryScore(Long memberId, DateRange range) {
+        LocalDateTime start = range.startDate().atStartOfDay();
+        LocalDateTime end = range.endExclusiveDate().atStartOfDay();
+
+        Double average = scenarioAnalysisResultRepository.findAverageMeaningDeliveryScore(
+                memberId,
+                start,
+                end
+        );
+
+        if (average == null) {
+            return null;
+        }
+
+        return  BigDecimal.valueOf(average).setScale(2, RoundingMode.HALF_UP);
+    }
+
     private LocalDate parseBaseDate(String baseDate) {
         if (baseDate == null || baseDate.isBlank()) {
             return LocalDate.now();
@@ -231,6 +411,14 @@ public class ReportServiceImpl implements ReportService {
         );
     }
 
+    private BigDecimal nullToZero(BigDecimal value) {
+        if (value == null) {
+            return BigDecimal.ZERO;
+        }
+
+        return value;
+    }
+
     private String toDayLabel(DayOfWeek dayOfWeek) {
         return switch (dayOfWeek) {
             case MONDAY -> "월";
@@ -246,5 +434,10 @@ public class ReportServiceImpl implements ReportService {
     private record DateRange(
             LocalDate startDate,
             LocalDate endExclusiveDate
+    ) {}
+
+    private record DateRangeWithLabel(
+            String label,
+            DateRange dateRange
     ) {}
 }

--- a/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioAnalysisResultRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioAnalysisResultRepository.java
@@ -28,6 +28,8 @@ public interface ScenarioAnalysisResultRepository extends JpaRepository<Scenario
             @Param("end") LocalDateTime end
     );
 
+    long countByMemberIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(Long memberId, LocalDateTime start, LocalDateTime end);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
             delete from ScenarioAnalysisResult result

--- a/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioAnalysisResultRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioAnalysisResultRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -13,6 +14,19 @@ public interface ScenarioAnalysisResultRepository extends JpaRepository<Scenario
     boolean existsByScenarioStepIdAndMemberId(Long scenarioStepId, Long memberId);
     Optional<ScenarioAnalysisResult> findTopByScenarioStepIdAndMemberIdOrderByCreatedAtDesc(Long scenarioStepId, Long memberId);
     Optional<ScenarioAnalysisResult> findByMemberIdAndClientRequestId(Long memberId, String clientRequestId);
+
+    @Query("""
+        select avg(result.pronunciationScore)
+        from ScenarioAnalysisResult result
+        where result.member.id = :memberId
+            and result.createdAt >= :start
+            and result.createdAt < :end
+    """)
+    Double findAveragePronunciationScore(
+            @Param("memberId") Long memberId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""

--- a/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioAnalysisResultRepository.java
+++ b/src/main/java/com/kwcapstone/server/domain/scenario/repository/ScenarioAnalysisResultRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Optional;
@@ -29,6 +30,32 @@ public interface ScenarioAnalysisResultRepository extends JpaRepository<Scenario
     );
 
     long countByMemberIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(Long memberId, LocalDateTime start, LocalDateTime end);
+
+    @Query("""
+        select coalesce(sum(result.pronunciationScore), 0)
+        from ScenarioAnalysisResult result
+        where result.member.id = :memberId
+            and result.createdAt >= :start
+            and result.createdAt < :end
+    """)
+    BigDecimal sumPronunciationScore(
+            @Param("memberId") Long memberId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
+
+    @Query("""
+        select avg(result.meaningDeliveryScore)
+        from ScenarioAnalysisResult result
+        where result.member.id = :memberId
+            and result.createdAt >= :start
+            and result.createdAt < :end
+    """)
+    Double findAverageMeaningDeliveryScore(
+            @Param("memberId") Long memberId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""

--- a/src/main/java/com/kwcapstone/server/global/security/SecurityConfig.java
+++ b/src/main/java/com/kwcapstone/server/global/security/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/warmups/**").authenticated()
                         .requestMatchers("/api/messages/**").authenticated()
                         .requestMatchers("/api/conversations/**").authenticated()
+                        .requestMatchers("/api/reports/**").authenticated()
                         .requestMatchers("/api/mypage/**").authenticated()
 
                         // 나머지


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #42

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

레포트 탭에서 사용하는 학습 통계 조회 API 구현

- 주/월 평균 발음 정확도 조회 API 구현
  - `GET /api/reports/pronunciation-accuracy`
  - 문장 노트, 기초 발성, 시나리오 유형별 평균 발음 정확도 조회
  - 이번 주/저번 주, 이번 달/저번 달 평균 비교
  - 현재 기간과 이전 기간의 차이값(diff) 반환
  - 데이터가 없는 경우 `null` 및 `hasCurrentData`, `hasPreviousData`로 구분

- 위클리 스탬프 조회 API 구현
  - `GET /api/reports/weekly-stamps`
  - 기준 날짜가 포함된 주의 월요일~일요일 학습 여부 조회
  - 날짜별 학습 여부, 학습 횟수, 완료한 연습 유형 반환

- 학습 성취도 추이 조회 API 구현
  - `GET /api/reports/achievement-trend`
  - 주간 조회 시 월~일 단위 추이 반환
  - 월간 조회 시 1~4주차 단위 추이 반환
  - 발음 정확도와 의미 전달률 추이 데이터 반환

- 기존 분석 결과 Repository에 통계 조회용 쿼리 추가
  - 기초 발성 연습 결과 평균/합계/개수 조회
  - 나만의 문장 분석 결과 평균/합계/개수 조회
  - 시나리오 분석 결과 평균/합계/개수 조회

- SecurityConfig에 `/api/reports/**` 인증 경로 추가


## 🧪 테스트 결과
> Apidog 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

아래 API의 정상 응답 확인

- [x] 주/월 평균 발음 정확도 조회
  - `GET /api/reports/pronunciation-accuracy?period=WEEK&type=MY_SENTENCE`
  - `GET /api/reports/pronunciation-accuracy?period=WEEK&type=BASIC`
  - `GET /api/reports/pronunciation-accuracy?period=WEEK&type=SCENARIO`
  - `GET /api/reports/pronunciation-accuracy?period=MONTH&type=MY_SENTENCE`
  - `GET /api/reports/pronunciation-accuracy?period=MONTH&type=BASIC`
  - `GET /api/reports/pronunciation-accuracy?period=MONTH&type=SCENARIO`

- [x] 위클리 스탬프 조회
  - `GET /api/reports/weekly-stamps`
  - `GET /api/reports/weekly-stamps?baseDate=2026-05-20` (선택)

- [x] 학습 성취도 추이 조회
  - `GET /api/reports/achievement-trend?period=WEEK`
  - `GET /api/reports/achievement-trend?period=MONTH`
  - `GET /api/reports/achievement-trend?period=WEEK&baseDate=2026-05-20` (선택)

확인한 내용

- [x] 인증된 사용자 기준 본인 학습 결과만 조회되는지 확인
- [x] 주간 기준이 월요일~일요일로 계산되는지 확인
- [x] 월간 기준이 해당 월 1일~말일로 계산되는지 확인
- [x] 이전 기간 데이터가 없는 경우 `previousAverage`, `diff`가 `null`로 반환되는지 확인
- [x] 학습 기록이 없는 날짜는 `hasStudy: false`로 반환되는지 확인
- [x] 학습 성취도 추이에서 데이터가 없는 구간은 `null`과 `hasData: false`로 구분되는지 확인

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

- 레포트 API는 별도의 통계 테이블을 생성하지 않고, 기존 분석 결과 테이블을 기간 기준으로 집계하는 방식으로 구현
- 발음 정확도는 다음 기준으로 계산
  - 문장 노트: `my_sentence_analysis_result.pronunciation_score`
  - 기초 발성: `basic_pronunciation_practice.accuracy_score`
  - 시나리오: `scenario_analysis_result.pronunciation_score`
- 학습 성취도 추이의 의미 전달률은 시나리오 연습 결과의 `meaning_delivery_score`를 기준으로 계산
- 데이터가 없는 경우 0점으로 처리하지 않고 `null`로 반환하여, 프론트에서 `0점`과 `데이터 없음`을 구분할 수 있도록 함
- `baseDate`는 테스트 및 특정 날짜 기준 조회를 위해 선택 파라미터로 추가하였음. 생략 시 서버의 현재 날짜를 기준으로 조회